### PR TITLE
🐛 fix hospit cage being reserved the whole day 

### DIFF
--- a/src/lib/components/lists/HospitList.svelte
+++ b/src/lib/components/lists/HospitList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { daysDiff, formatDateStringShort, formatFilterDate } from '$lib/utils/date';
+	import { daysDiff, formatDateStringShortDay, formatFilterDate } from '$lib/utils/date';
 	import type { HospitStatusFilter as StatusFilter } from '$types';
 	import { hospitPageInfo } from '$store/hospit';
 	import { goto } from '$app/navigation';
@@ -248,11 +248,11 @@
 										>
 										<td
 											class="px-4 text-sm text-gray-500 dark:text-gray-300 truncate lg:overflow-hidden max-w-sm"
-											>{formatDateStringShort(item.start)}</td
+											>{formatDateStringShortDay(item.start)}</td
 										>
 										<td
 											class="px-4 text-sm text-gray-500 dark:text-gray-300 truncate lg:overflow-hidden max-w-sm"
-											>{formatDateStringShort(item.end)}</td
+											>{formatDateStringShortDay(item.end)}</td
 										>
 										<td
 											class="px-4 text-sm truncate lg:overflow-hidden font-semibold max-w-sm {item

--- a/src/lib/components/tabs/visit/HospitTab.svelte
+++ b/src/lib/components/tabs/visit/HospitTab.svelte
@@ -165,7 +165,7 @@
 							bind:value={$form.start}
 							timePrecision="minute"
 							closeOnSelection={true}
-							format="yyyy-MM-dd"
+							format="yyyy-MM-dd HH:mm"
 							{locale}
 						/>
 					</div>
@@ -195,7 +195,7 @@
 							bind:value={$form.end}
 							id="enddate"
 							min={$form.start}
-							format="yyyy-MM-dd"
+							format="yyyy-MM-dd HH:mm"
 							closeOnSelection={true}
 							timePrecision="minute"
 							{locale}

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -8,7 +8,18 @@ import locale from 'date-fns/locale/fr/index';
  * @returns {string} the formatted date string
  */
 export const formatDateString = (timestamp: string): string =>
-	format(new Date(timestamp), 'EEEE dd/LL/yyyy  HH:mm', {
+	format(new Date(timestamp), 'EEEE dd/LL/yyyy HH:mm', {
+		locale
+	});
+
+/**
+ * format a timestamp string to a string with short day name
+ *
+ * @param {string} timestamp - the timestamp to format
+ * @returns {string} the formatted date string
+ */
+export const formatDateStringShortDay = (timestamp: string): string =>
+	format(new Date(timestamp), 'E dd/LL/yyyy HH:mm', {
 		locale
 	});
 


### PR DESCRIPTION
- calculate available cages based on hospit end date.
- display the time part of the date in the UI