### PR TITLE
feat(payment): add virement (bank transfer) payment method

### DIFF
--- a/src/lib/components/charts/funds/FundsPaymentMethodsStats.svelte
+++ b/src/lib/components/charts/funds/FundsPaymentMethodsStats.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { FundPaymentMethodsStats } from '$types';
 	import currency from 'currency.js';
+	import { getPaymentMethodLabel } from '$utils/payment';
 
 	export let stats: FundPaymentMethodsStats;
 
@@ -50,8 +51,8 @@
 					{#each items as item}
 						<tr
 							><th
-								class="max-w-lg border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs p-4 text-left uppercase"
-								>{item.method}</th
+								class="max-w-lg border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs p-4 text-left"
+								>{getPaymentMethodLabel(item.method)}</th
 							>
 							<td class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs p-4 text-center"
 								>{item.count}</td

--- a/src/lib/components/lists/FundsList.svelte
+++ b/src/lib/components/lists/FundsList.svelte
@@ -18,6 +18,7 @@
 	import MoneyBagIcon from '$components/icons/MoneyBagIcon.svelte';
 	import MoneyOutIcon from '$components/icons/MoneyOutIcon.svelte';
 	import DoubleArrow from '$components/icons/DoubleArrow.svelte';
+	import { getPaymentMethodLabel } from '$utils/payment';
 
 	let locale = localeFromDateFnsLocale(fr);
 	let openAddFundsForm = false;
@@ -351,10 +352,8 @@
 											</td>
 											<td class="px-4 py-3 text-sm whitespace-nowrap">
 												<div class="flex gap-2">
-													<div
-														class="text-sm pt-1 font-normal text-gray-600 dark:text-gray-400 uppercase"
-													>
-														{item.method}
+													<div class="text-sm pt-1 font-normal text-gray-600 dark:text-gray-400">
+														{getPaymentMethodLabel(item.method)}
 													</div>
 													{#if item.method === 'cash'}
 														<div class="flex flex-row gap-1">

--- a/src/lib/components/tabs/visit/PaymentTab.svelte
+++ b/src/lib/components/tabs/visit/PaymentTab.svelte
@@ -12,6 +12,7 @@
 	import DollarBill from '$components/icons/DollarBill.svelte';
 	import { toast } from 'svelte-sonner';
 	import { formatDateStringShortDay } from '$lib/utils/date';
+	import { getPaymentMethodLabel } from '$lib/utils/payment';
 
 	export let bill: PaymentInformation;
 
@@ -176,8 +177,8 @@
 							>{formatDateStringShortDay(history.created)}
 						</button>
 						<span class="font-bold text-gray-800 dark:text-gray-200">{history.amount} DT</span>
-						<span class="font-bold text-gray-800 dark:text-gray-200 uppercase"
-							>{history.method}</span
+						<span class="font-bold text-gray-800 dark:text-gray-200"
+							>{getPaymentMethodLabel(history.method)}</span
 						>
 					</div>
 					{#if history.description.length > 0}

--- a/src/lib/utils/payment.ts
+++ b/src/lib/utils/payment.ts
@@ -1,4 +1,4 @@
-import type { PaymentMethod } from '$types';
+import type { PaymentMethod, PaymentMethodType } from '$types';
 
 export const paymentMethods: PaymentMethod[] = [
 	{
@@ -12,5 +12,14 @@ export const paymentMethods: PaymentMethod[] = [
 	{
 		label: 'Chèque',
 		value: 'cheque'
+	},
+	{
+		label: 'Virement',
+		value: 'virement'
 	}
 ];
+
+export const getPaymentMethodLabel = (method: PaymentMethodType | string): string => {
+	const found = paymentMethods.find((pm) => pm.value === method);
+	return found?.label ?? method;
+};

--- a/src/pocketbase-types.ts
+++ b/src/pocketbase-types.ts
@@ -280,7 +280,8 @@ export type AvailableCagesRecord = {
 export enum BillsMethodOptions {
 	'cash' = 'cash',
 	'tpe' = 'tpe',
-	'cheque' = 'cheque'
+	'cheque' = 'cheque',
+	'virement' = 'virement'
 }
 export type BillsRecord = {
 	method?: BillsMethodOptions;
@@ -328,7 +329,8 @@ export type DoctorsRecord = {
 export enum FundTransactionsMethodOptions {
 	'cash' = 'cash',
 	'tpe' = 'tpe',
-	'cheque' = 'cheque'
+	'cheque' = 'cheque',
+	'virement' = 'virement'
 }
 export type FundTransactionsRecord = {
 	amount?: number;
@@ -391,7 +393,8 @@ export type InventoryItemRecord = {
 export enum InventorySaleMethodOptions {
 	'cash' = 'cash',
 	'tpe' = 'tpe',
-	'cheque' = 'cheque'
+	'cheque' = 'cheque',
+	'virement' = 'virement'
 }
 export type InventorySaleRecord = {
 	incash?: number;
@@ -427,8 +430,8 @@ export type ToilettageRecord = {
 };
 
 export enum UsersRoleOptions {
-	'operator' = 'operator',
-	'editor' = 'editor'
+	'editor' = 'editor',
+	'operator' = 'operator'
 }
 export type UsersRecord = {
 	avatar?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,7 +79,7 @@ export interface IClient extends Omit<ClientsResponse, 'animals'> {
 	animals: AnimalsResponse[];
 }
 
-export type PaymentMethodType = 'cash' | 'tpe' | 'cheque';
+export type PaymentMethodType = 'cash' | 'tpe' | 'cheque' | 'virement';
 export interface PaymentMethod {
 	value: PaymentMethodType;
 	label: string;


### PR DESCRIPTION
  ## Summary
  - Add support for "Virement" (bank transfer) as a new payment method alongside cash, TPE, and cheque
  - Add `getPaymentMethodLabel()` helper function to display proper French labels instead of raw method values
  - Update payment method display across funds list, visit payments, and statistics

  ## Changes
  - `src/types.ts` - Added `virement` to `PaymentMethodType`
  - `src/lib/utils/payment.ts` - Added Virement option and label helper
  - `src/pocketbase-types.ts` - Updated Pocketbase enums
  - Updated display components to use French labels (Espèces, TPE, Chèque, Virement)
