### PR TITLE
fix: hospitalisation duration showing 0 days for overnight stays

### DIFF
--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -1,4 +1,4 @@
-import { format, addDays, setHours, setMinutes, differenceInDays } from 'date-fns';
+import { format, addDays, startOfDay, differenceInDays } from 'date-fns';
 import locale from 'date-fns/locale/fr/index';
 
 /**
@@ -173,8 +173,8 @@ export const formatDateTime = (date: string): string =>
  * @returns {number} the number of days between the two dates
  */
 export const getDaysBetween = (start: string, end: string): number => {
-	const startDate = setHours(setMinutes(new Date(start), 0), 0);
-	const endDate = setHours(setMinutes(new Date(end), 0), 24);
+	const startDate = startOfDay(new Date(start));
+	const endDate = addDays(startOfDay(new Date(end)), 1);
 
 	return Math.max(differenceInDays(endDate, startDate) - 1, 0);
 };
@@ -187,8 +187,8 @@ export const getDaysBetween = (start: string, end: string): number => {
  * @returns {number} the number of days between the two dates
  */
 export const daysDiff = (start: string, end: string): number => {
-	const startDate = setHours(setMinutes(new Date(start), 0), 0);
-	const endDate = setHours(setMinutes(new Date(end), 0), 0);
+	const startDate = startOfDay(new Date(start));
+	const endDate = startOfDay(new Date(end));
 
 	return differenceInDays(endDate, startDate);
 };


### PR DESCRIPTION
## Summary
  - Fixes bug where hospitalisation from day 13 to day 14 showed "0 jours" instead of "1 jour"
  - Root cause: `setHours`/`setMinutes` don't reset seconds and milliseconds
  - Solution: Use `startOfDay` from date-fns which properly normalizes to midnight (00:00:00.000)

  ## Problem
  When start date had milliseconds (e.g., `2026-02-13T20:28:20.067Z`) and end date didn't (`2026-02-14T20:28:00.000Z`), the difference calculation was off by a fraction of a day, causing `differenceInDays` to truncate incorrectly.
