### PR TITLE
fix(security): harden auth cookie configuration

### DIFF
--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,13 +1,6 @@
 import pb from '$lib/pocketbase';
 import { currentUser } from '$store/user';
 
-pb.authStore.loadFromCookie(document.cookie);
-
 pb.authStore.onChange(() => {
 	currentUser.set(pb.authStore.model);
-	document.cookie = pb.authStore.exportToCookie({
-		httpOnly: false,
-		sameSite: 'Lax',
-		secure: false
-	});
-}, true);
+});

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -24,12 +24,14 @@ export const handle: Handle = async ({ event, resolve }) => {
 
 	const response = await resolve(event);
 
+	const isSecure = event.url.protocol === 'https:';
+
 	response.headers.append(
 		'set-cookie',
 		event.locals.pb.authStore.exportToCookie({
-			httpOnly: false,
+			httpOnly: true,
 			sameSite: 'Lax',
-			secure: false
+			secure: isSecure
 		})
 	);
 


### PR DESCRIPTION
## Summary
- Set `httpOnly: true` on auth cookies to prevent JavaScript access to tokens
- Set `secure` flag dynamically based on protocol (HTTPS in production, HTTP in dev)
- Removed client-side cookie read/write in `hooks.client.ts` since auth state is managed server-side

Closes #428
