### PR TITLE
fix(security): use parameterized filters for Pocketbase queries

### DIFF
--- a/src/lib/services/funds.ts
+++ b/src/lib/services/funds.ts
@@ -123,12 +123,16 @@ export class FundsService {
 			filter === 'income' ? '&& amount > 0' : filter === 'expense' ? '&& amount < 0' : '';
 
 		const queryFilter = startDate.startsWith('@')
-			? `created >= ${startDate} && created <= ${endDate} && (description ~ "${query}" || amount ~ "${query}") ${filterString}`
+			? this.pb.filter(
+					`created >= ${startDate} && created <= ${endDate} && (description ~ {:q} || amount ~ {:q}) ${filterString}`,
+					{ q: query }
+			  )
 			: this.pb.filter(
-					`created >= {:start} && created <= {:end} && (description ~ "${query}" || amount ~ "${query}") ${filterString}`,
+					`created >= {:start} && created <= {:end} && (description ~ {:q} || amount ~ {:q}) ${filterString}`,
 					{
-						start: startDate.startsWith('@') ? startDate : new Date(startDate),
-						end: endDate.startsWith('@') ? endDate : new Date(endDate)
+						start: new Date(startDate),
+						end: new Date(endDate),
+						q: query
 					}
 			  );
 
@@ -226,7 +230,10 @@ export class FundsService {
 		const balance = currency(income).subtract(expense).value;
 
 		const unpaidBills = await this.pb.collection('bills').getFullList<BillsResponse>({
-			filter: `total_paid < total && created >= "${startDate}" && created <= "${endDate}"`
+			filter: this.pb.filter('total_paid < total && created >= {:start} && created <= {:end}', {
+				start: new Date(startDate),
+				end: new Date(endDate)
+			})
 		});
 
 		const remaining = unpaidBills.reduce(

--- a/src/routes/(app)/animals/+page.server.ts
+++ b/src/routes/(app)/animals/+page.server.ts
@@ -21,7 +21,9 @@ export const load: PageServerLoad = async ({ locals: { pb }, url: { searchParams
 			: filter === 'female'
 			? 'animals_female_list'
 			: 'animals';
-	const queryFilter = `name ~ "${query}" || type ~ "${query}" ||  breed ~ "${query}" || identifier ~ "${query}"`;
+	const queryFilter = pb.filter('name ~ {:q} || type ~ {:q} || breed ~ {:q} || identifier ~ {:q}', {
+		q: query
+	});
 
 	const animalsPage = await pb.collection(collection).getList<AnimalsResponse>(page, 10, {
 		sort: '-created',

--- a/src/routes/(app)/clients/+page.server.ts
+++ b/src/routes/(app)/clients/+page.server.ts
@@ -17,7 +17,9 @@ export const load: PageServerLoad = async ({ locals: { pb }, url: { searchParams
 
 	const clientsPage = await pb.collection('clients').getList<ClientsResponse>(page, 10, {
 		expand: 'animals(client)',
-		filter: `name ~ "${query}" || tel ~ "${query}" || address ~ "${query}" || email ~ "${query}"`,
+		filter: pb.filter('name ~ {:q} || tel ~ {:q} || address ~ {:q} || email ~ {:q}', {
+			q: query
+		}),
 		sort: '-created'
 	});
 

--- a/src/routes/(app)/hospit/+page.server.ts
+++ b/src/routes/(app)/hospit/+page.server.ts
@@ -21,7 +21,10 @@ export const load = (async ({ locals: { pb }, url: { searchParams } }) => {
 			: filter === 'complete'
 			? 'hospit_completed_list'
 			: 'hospitalisation';
-	const queryFilter = `note ~ "${query}" || cage.code ~ "${query}" || visit.animal.name ~ "${query}" || visit.animal.identifier ~ "${query}" || visit.animal.client.name ~ "${query}" || visit.animal.client.tel ~ "${query}"`;
+	const queryFilter = pb.filter(
+		'note ~ {:q} || cage.code ~ {:q} || visit.animal.name ~ {:q} || visit.animal.identifier ~ {:q} || visit.animal.client.name ~ {:q} || visit.animal.client.tel ~ {:q}',
+		{ q: query }
+	);
 
 	const hospit = await pb.collection(collection).getList<HospitalisationResponse>(page, 10, {
 		sort: '-updated',

--- a/src/routes/(app)/search/+page.server.ts
+++ b/src/routes/(app)/search/+page.server.ts
@@ -10,8 +10,12 @@ export const load = (async ({ locals: { pb }, url: { searchParams } }) => {
 	const searchCollection = target === 'animal' ? 'animals' : 'clients';
 	const searchFilter =
 		target === 'animal'
-			? `name ~ "${query}" || identifier ~ "${query}" || type ~ "${query}" || breed ~ "${query}"`
-			: `name ~ "${query}" || tel ~ "${query}" || email ~ "${query}" || address ~ "${query}"`;
+			? pb.filter('name ~ {:q} || identifier ~ {:q} || type ~ {:q} || breed ~ {:q}', {
+					q: query
+			  })
+			: pb.filter('name ~ {:q} || tel ~ {:q} || email ~ {:q} || address ~ {:q}', {
+					q: query
+			  });
 	const searchExpand = target === 'animal' ? `client` : `animals(client)`;
 
 	const results = await pb

--- a/src/routes/(app)/store/+page.server.ts
+++ b/src/routes/(app)/store/+page.server.ts
@@ -94,7 +94,7 @@ export const actions: Actions = {
 
 			const item = await pb
 				.collection('inventory_item')
-				.getList(1, 1, { filter: `code = '${addForm.data.code}'` });
+				.getList(1, 1, { filter: pb.filter('code = {:code}', { code: addForm.data.code }) });
 
 			if (item.totalItems != 0) {
 				return setError(addForm, 'Code déjà utilisé');

--- a/src/routes/(app)/visit/+page.server.ts
+++ b/src/routes/(app)/visit/+page.server.ts
@@ -35,7 +35,10 @@ export const load = (async ({ locals: { pb }, url }) => {
 		sort: '-updated',
 		...(query?.length
 			? {
-					filter: `animal.name ~ "${query}" || motif ~ "${query}" || animal.client.name ~ "${query}" || animal.client.tel ~ "${query}"`
+					filter: pb.filter(
+						'animal.name ~ {:q} || motif ~ {:q} || animal.client.name ~ {:q} || animal.client.tel ~ {:q}',
+						{ q: query }
+					)
 			  }
 			: {})
 	} satisfies RecordListOptions;


### PR DESCRIPTION
## Summary
- Replace all raw string interpolation in Pocketbase filter queries with `pb.filter()` parameterized helper
- Affects search queries across clients, animals, visits, hospitalisation, search, store, and funds
- Prevents filter injection via crafted search inputs containing quote characters

Closes #429
