### PR TITLE
test: add unit tests for date utilities and BillService

### DIFF
--- a/src/lib/services/bill.test.ts
+++ b/src/lib/services/bill.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import BillService from './bill';
+import type { VisitsResponse, ItemMetadata } from '$types';
+
+const createMockVisit = (overrides = {}): VisitsResponse<ItemMetadata[]> =>
+	({
+		id: 'visit1',
+		visit_price: 0,
+		item_metadata: [],
+		expand: {},
+		...overrides
+	} as unknown as VisitsResponse<ItemMetadata[]>);
+
+const mockPb = {} as never;
+const mockVisitRef = { id: 'visit1' } as never;
+
+describe('BillService cost calculations', () => {
+	describe('getToilettagePrice', () => {
+		it('returns 0 when no toilettage items', () => {
+			const service = new BillService(mockPb, mockVisitRef);
+			const visit = createMockVisit();
+			expect(service.getToilettagePrice(visit)).toBe(0);
+		});
+
+		it('sums prices of toilettage items', () => {
+			const service = new BillService(mockPb, mockVisitRef);
+			const visit = createMockVisit({
+				expand: {
+					toilettage: [
+						{ id: 'a', price: 50 },
+						{ id: 'b', price: 30 }
+					]
+				}
+			});
+			expect(service.getToilettagePrice(visit)).toBe(80);
+		});
+
+		it('applies discount from metadata', () => {
+			const service = new BillService(mockPb, mockVisitRef);
+			const visit = createMockVisit({
+				item_metadata: [{ item: 'a', discount: 20, quantity: 1 }],
+				expand: {
+					toilettage: [{ id: 'a', price: 100 }]
+				}
+			});
+			// 100 * (1 - 20/100) = 80
+			expect(service.getToilettagePrice(visit)).toBe(80);
+		});
+
+		it('applies quantity from metadata', () => {
+			const service = new BillService(mockPb, mockVisitRef);
+			const visit = createMockVisit({
+				item_metadata: [{ item: 'a', discount: 0, quantity: 3 }],
+				expand: {
+					toilettage: [{ id: 'a', price: 25 }]
+				}
+			});
+			// 25 * 3 = 75
+			expect(service.getToilettagePrice(visit)).toBe(75);
+		});
+
+		it('applies both discount and quantity', () => {
+			const service = new BillService(mockPb, mockVisitRef);
+			const visit = createMockVisit({
+				item_metadata: [{ item: 'a', discount: 50, quantity: 2 }],
+				expand: {
+					toilettage: [{ id: 'a', price: 100 }]
+				}
+			});
+			// 100 * (1 - 50/100) = 50, then 50 * 2 = 100
+			expect(service.getToilettagePrice(visit)).toBe(100);
+		});
+	});
+
+	describe('getMedicalActsCost', () => {
+		it('returns 0 when no medical acts', () => {
+			const service = new BillService(mockPb, mockVisitRef);
+			const visit = createMockVisit();
+			expect(service.getMedicalActsCost(visit)).toBe(0);
+		});
+
+		it('sums medical acts prices with metadata', () => {
+			const service = new BillService(mockPb, mockVisitRef);
+			const visit = createMockVisit({
+				item_metadata: [{ item: 'med1', discount: 10, quantity: 2 }],
+				expand: {
+					medical_acts: [
+						{ id: 'med1', price: 200 },
+						{ id: 'med2', price: 50 }
+					]
+				}
+			});
+			// med1: 200 * 0.9 = 180, * 2 = 360
+			// med2: 50 * 1 (no metadata) = 50
+			expect(service.getMedicalActsCost(visit)).toBe(410);
+		});
+	});
+
+	describe('getSurgicalActsCost', () => {
+		it('returns 0 when no surgical acts', () => {
+			const service = new BillService(mockPb, mockVisitRef);
+			const visit = createMockVisit();
+			expect(service.getSurgicalActsCost(visit)).toBe(0);
+		});
+
+		it('calculates with discount and quantity', () => {
+			const service = new BillService(mockPb, mockVisitRef);
+			const visit = createMockVisit({
+				item_metadata: [{ item: 's1', discount: 25, quantity: 1 }],
+				expand: {
+					surgical_acts: [{ id: 's1', price: 400 }]
+				}
+			});
+			// 400 * 0.75 = 300
+			expect(service.getSurgicalActsCost(visit)).toBe(300);
+		});
+	});
+
+	describe('getInventoryItemsCost', () => {
+		it('returns 0 when no store items', () => {
+			const service = new BillService(mockPb, mockVisitRef);
+			const visit = createMockVisit();
+			expect(service.getInventoryItemsCost(visit)).toBe(0);
+		});
+
+		it('calculates multiple items with varying metadata', () => {
+			const service = new BillService(mockPb, mockVisitRef);
+			const visit = createMockVisit({
+				item_metadata: [
+					{ item: 'i1', discount: 0, quantity: 5 },
+					{ item: 'i2', discount: 50, quantity: 1 }
+				],
+				expand: {
+					store_items: [
+						{ id: 'i1', price: 10 },
+						{ id: 'i2', price: 60 }
+					]
+				}
+			});
+			// i1: 10 * 5 = 50, i2: 60 * 0.5 = 30
+			expect(service.getInventoryItemsCost(visit)).toBe(80);
+		});
+	});
+
+	describe('getHospitalisationCost', () => {
+		it('returns 0 when no hospitalisation', async () => {
+			const service = new BillService(mockPb, mockVisitRef);
+			const visit = createMockVisit();
+			expect(await service.getHospitalisationCost(visit)).toBe(0);
+		});
+
+		it('calculates cost based on days and price', async () => {
+			const service = new BillService(mockPb, mockVisitRef);
+			const visit = createMockVisit({
+				expand: {
+					hospit: {
+						start: '2024-01-15T08:00:00',
+						end: '2024-01-18T08:00:00',
+						price: 50
+					}
+				}
+			});
+			// 3 nights between Jan 15-18 (getDaysBetween returns 3), * 50 = 150
+			expect(await service.getHospitalisationCost(visit)).toBe(150);
+		});
+
+		it('returns 0 for same-day hospitalisation', async () => {
+			const service = new BillService(mockPb, mockVisitRef);
+			const visit = createMockVisit({
+				expand: {
+					hospit: {
+						start: '2024-01-15T08:00:00',
+						end: '2024-01-15T20:00:00',
+						price: 50
+					}
+				}
+			});
+			expect(await service.getHospitalisationCost(visit)).toBe(0);
+		});
+	});
+});

--- a/src/lib/utils/date.test.ts
+++ b/src/lib/utils/date.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { getDaysBetween, daysDiff, calculateDiff, sortDates, getPreviousDays } from './date';
+
+describe('getDaysBetween', () => {
+	it('returns 0 for same-day start and end', () => {
+		expect(getDaysBetween('2024-01-15T08:00:00', '2024-01-15T20:00:00')).toBe(0);
+	});
+
+	it('returns 1 for overnight stay (1 night)', () => {
+		expect(getDaysBetween('2024-01-15T08:00:00', '2024-01-16T08:00:00')).toBe(1);
+	});
+
+	it('returns 2 for a 2-night stay', () => {
+		expect(getDaysBetween('2024-01-15T08:00:00', '2024-01-17T08:00:00')).toBe(2);
+	});
+
+	it('returns correct days for longer stays', () => {
+		expect(getDaysBetween('2024-01-15T08:00:00', '2024-01-20T08:00:00')).toBe(5);
+	});
+
+	it('handles dates with milliseconds', () => {
+		expect(getDaysBetween('2024-01-15T08:00:00.123', '2024-01-17T20:00:00.456')).toBe(2);
+	});
+
+	it('returns 0 when start equals end', () => {
+		expect(getDaysBetween('2024-01-15T08:00:00', '2024-01-15T08:00:00')).toBe(0);
+	});
+
+	it('returns 0 when end is before start (negative result clamped)', () => {
+		expect(getDaysBetween('2024-01-17T08:00:00', '2024-01-15T08:00:00')).toBe(0);
+	});
+});
+
+describe('daysDiff', () => {
+	it('returns 0 for same day', () => {
+		expect(daysDiff('2024-01-15T08:00:00', '2024-01-15T20:00:00')).toBe(0);
+	});
+
+	it('returns 1 for consecutive days', () => {
+		expect(daysDiff('2024-01-15T08:00:00', '2024-01-16T08:00:00')).toBe(1);
+	});
+
+	it('returns negative for reversed dates', () => {
+		expect(daysDiff('2024-01-17T08:00:00', '2024-01-15T08:00:00')).toBe(-2);
+	});
+
+	it('returns correct value for multi-day span', () => {
+		expect(daysDiff('2024-01-15T00:00:00', '2024-01-20T00:00:00')).toBe(5);
+	});
+});
+
+describe('calculateDiff', () => {
+	it('formats hours, minutes, and seconds', () => {
+		const start = '2024-01-15T10:00:00';
+		const end = new Date('2024-01-15T12:30:45').getTime();
+		expect(calculateDiff(start, end)).toBe('2h 30m 45s');
+	});
+
+	it('omits hours when zero', () => {
+		const start = '2024-01-15T10:00:00';
+		const end = new Date('2024-01-15T10:05:30').getTime();
+		expect(calculateDiff(start, end)).toBe('5m 30s');
+	});
+
+	it('omits minutes when zero', () => {
+		const start = '2024-01-15T10:00:00';
+		const end = new Date('2024-01-15T11:00:10').getTime();
+		expect(calculateDiff(start, end)).toBe('1h 10s');
+	});
+
+	it('returns empty string for zero diff', () => {
+		const start = '2024-01-15T10:00:00';
+		const end = new Date('2024-01-15T10:00:00').getTime();
+		expect(calculateDiff(start, end)).toBe('');
+	});
+});
+
+describe('sortDates', () => {
+	it('returns positive when end is after start', () => {
+		expect(sortDates('2024-01-15', '2024-01-20')).toBeGreaterThan(0);
+	});
+
+	it('returns negative when end is before start', () => {
+		expect(sortDates('2024-01-20', '2024-01-15')).toBeLessThan(0);
+	});
+
+	it('returns 0 for equal dates', () => {
+		expect(sortDates('2024-01-15', '2024-01-15')).toBe(0);
+	});
+});
+
+describe('getPreviousDays', () => {
+	it('returns 7 days by default ending at the given date', () => {
+		const date = new Date('2024-01-15');
+		const result = getPreviousDays(date);
+		expect(result).toHaveLength(7);
+		expect(result[6].toDateString()).toBe(date.toDateString());
+	});
+
+	it('respects custom length', () => {
+		const date = new Date('2024-01-15');
+		const result = getPreviousDays(date, 3);
+		expect(result).toHaveLength(3);
+	});
+
+	it('returns dates in chronological order', () => {
+		const date = new Date('2024-01-15');
+		const result = getPreviousDays(date, 5);
+		for (let i = 1; i < result.length; i++) {
+			expect(result[i].getTime()).toBeGreaterThan(result[i - 1].getTime());
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- Add 35 unit tests covering date utilities and BillService cost calculations
- Date tests cover `getDaysBetween` (the recently bugfixed function), `daysDiff`, `calculateDiff`, `sortDates`, and `getPreviousDays`
- BillService tests cover all cost calculation methods with discount/quantity metadata handling

Closes #432
