### PR TITLE
refactor: extract shared pagination utility from list components

### DIFF
--- a/src/lib/components/lists/ActivityList.svelte
+++ b/src/lib/components/lists/ActivityList.svelte
@@ -3,8 +3,12 @@
 	import { formatDateStringShort, formatDateStringToTime } from '$lib/utils/date';
 	import { activityPage } from '$store/activity';
 	import PaymentStatus from '$components/display/PaymentStatus.svelte';
-	import { goto } from '$app/navigation';
-	import { browser } from '$app/environment';
+	import {
+		nextPage as goNextPage,
+		previousPage as goPreviousPage,
+		dispatchSearch as doSearch,
+		changeTab as doChangeTab
+	} from '$utils/pagination';
 	import currency from 'currency.js';
 	import SearchIcon from '$components/icons/SearchIcon.svelte';
 	import BackArrow from '$components/icons/BackArrow.svelte';
@@ -15,48 +19,10 @@
 	let search: string = $activityPage.query;
 	let page = $activityPage.page;
 
-	$: currentUrl = browser ? document.location.href : '';
-
-	$: nextPage = () => {
-		if ($activityPage.page >= $activityPage.totalPages) return;
-
-		const nextUrl = new URL(currentUrl);
-
-		nextUrl.searchParams.set('page', `${$activityPage.page + 1}`);
-
-		goto(nextUrl);
-	};
-
-	$: previousPage = () => {
-		if ($activityPage.page <= 1) return;
-
-		const prevUrl = new URL(currentUrl);
-
-		prevUrl.searchParams.set('page', `${$activityPage.page - 1}`);
-		goto(prevUrl);
-	};
-
-	$: dispatchSearch = () => {
-		const searchUrl = new URL(currentUrl);
-
-		searchUrl.searchParams.set('query', search);
-		searchUrl.searchParams.delete('page');
-		goto(searchUrl);
-	};
-
-	$: changeTab = (filter: StatusFilter) => {
-		const filterUrl = new URL(currentUrl);
-
-		filterUrl.searchParams.delete('page');
-
-		if (filter === 'all') {
-			filterUrl.searchParams.delete('filter');
-		} else {
-			filterUrl.searchParams.set('filter', filter);
-		}
-
-		goto(filterUrl);
-	};
+	$: nextPage = () => goNextPage($activityPage.page, $activityPage.totalPages);
+	$: previousPage = () => goPreviousPage($activityPage.page);
+	$: dispatchSearch = () => doSearch(search);
+	$: changeTab = (filter: StatusFilter) => doChangeTab(filter);
 </script>
 
 <div class="flex flex-col items-center justify-start xl:pl-14 w-full">

--- a/src/lib/components/lists/AnimalList.svelte
+++ b/src/lib/components/lists/AnimalList.svelte
@@ -9,8 +9,12 @@
 	import AddAnimalForm from '$components/forms/animals/AddAnimalForm.svelte';
 	import UpdateAnimalForm from '$components/forms/animals/updateAnimalForm.svelte';
 	import AnimalIcon from '$components/display/animal/AnimalIcon.svelte';
-	import { browser } from '$app/environment';
-	import { goto } from '$app/navigation';
+	import {
+		nextPage as goNextPage,
+		previousPage as goPreviousPage,
+		dispatchSearch as doSearch,
+		changeTab as doChangeTab
+	} from '$utils/pagination';
 	import SearchIcon from '$components/icons/SearchIcon.svelte';
 	import PlusIcon from '$components/icons/PlusIcon.svelte';
 	import BackArrow from '$components/icons/BackArrow.svelte';
@@ -29,8 +33,6 @@
 	let selectedItem: AnimalsResponse | null;
 	let deleteFormRef: HTMLFormElement;
 	let selectedUpdateItem: AnimalsResponse | null;
-
-	$: currentUrl = browser ? document.location.href : '';
 
 	$: removeHandler = () => {
 		deleteFormRef.requestSubmit();
@@ -51,45 +53,10 @@
 		openUpdateAnimalModal = true;
 	};
 
-	$: nextPage = () => {
-		if ($animalsPageInfo.page >= $animalsPageInfo.totalPages) return;
-
-		const nextUrl = new URL(currentUrl);
-
-		nextUrl.searchParams.set('page', `${$animalsPageInfo.page + 1}`);
-		goto(nextUrl);
-	};
-
-	$: previousPage = () => {
-		if ($animalsPageInfo.page <= 1) return;
-
-		const previousUrl = new URL(currentUrl);
-
-		previousUrl.searchParams.set('page', `${$animalsPageInfo.page - 1}`);
-		goto(previousUrl);
-	};
-
-	$: dispatchSearch = () => {
-		const searchUrl = new URL(currentUrl);
-
-		searchUrl.searchParams.set('query', search);
-		searchUrl.searchParams.delete('page');
-		goto(searchUrl);
-	};
-
-	$: changeTab = (tab: StatusFilter) => {
-		const filterUrl = new URL(currentUrl);
-
-		filterUrl.searchParams.delete('page');
-
-		if (tab === 'all') {
-			filterUrl.searchParams.delete('filter');
-		} else {
-			filterUrl.searchParams.set('filter', tab);
-		}
-
-		goto(filterUrl);
-	};
+	$: nextPage = () => goNextPage($animalsPageInfo.page, $animalsPageInfo.totalPages);
+	$: previousPage = () => goPreviousPage($animalsPageInfo.page);
+	$: dispatchSearch = () => doSearch(search);
+	$: changeTab = (tab: StatusFilter) => doChangeTab(tab);
 
 	const {
 		enhance,

--- a/src/lib/components/lists/ClientList.svelte
+++ b/src/lib/components/lists/ClientList.svelte
@@ -7,8 +7,11 @@
 	import Avatar from '$components/Avatar.svelte';
 	import AddClientForm from '../forms/clients/AddClientForm.svelte';
 	import UpdateClientForm from '../forms/clients/UpdateClientForm.svelte';
-	import { browser } from '$app/environment';
-	import { goto } from '$app/navigation';
+	import {
+		nextPage as goNextPage,
+		previousPage as goPreviousPage,
+		dispatchSearch as doSearch
+	} from '$utils/pagination';
 	import SearchIcon from '$components/icons/SearchIcon.svelte';
 	import PlusIcon from '$components/icons/PlusIcon.svelte';
 	import BackArrow from '$components/icons/BackArrow.svelte';
@@ -27,34 +30,9 @@
 	let deleteFormRef: HTMLFormElement;
 	let selectedUpdateItem: IClient | null;
 
-	$: currentUrl = browser ? document.location.href : '';
-
-	$: nextPage = () => {
-		if ($clientsPageInfo.page >= $clientsPageInfo.totalPages) return;
-
-		const nextUrl = new URL(currentUrl);
-
-		nextUrl.searchParams.set('page', `${$clientsPageInfo.page + 1}`);
-
-		goto(nextUrl);
-	};
-
-	$: previousPage = () => {
-		if ($clientsPageInfo.page <= 1) return;
-
-		const prevUrl = new URL(currentUrl);
-
-		prevUrl.searchParams.set('page', `${$clientsPageInfo.page - 1}`);
-		goto(prevUrl);
-	};
-
-	$: dispatchSearch = () => {
-		const searchUrl = new URL(currentUrl);
-
-		searchUrl.searchParams.set('query', search);
-		searchUrl.searchParams.delete('page');
-		goto(searchUrl);
-	};
+	$: nextPage = () => goNextPage($clientsPageInfo.page, $clientsPageInfo.totalPages);
+	$: previousPage = () => goPreviousPage($clientsPageInfo.page);
+	$: dispatchSearch = () => doSearch(search);
 
 	const deleteHandler = () => {
 		deleteFormRef.requestSubmit();

--- a/src/lib/components/lists/FundsList.svelte
+++ b/src/lib/components/lists/FundsList.svelte
@@ -8,8 +8,14 @@
 	import fr from 'date-fns/locale/fr/index';
 	import type { fundsStatusFilter as StatusFilter } from '$types';
 	import { format, setHours, setMinutes } from 'date-fns';
+	import {
+		nextPage as goNextPage,
+		previousPage as goPreviousPage,
+		dispatchSearch as doSearch,
+		changeTab as doChangeTab,
+		getCurrentUrl
+	} from '$utils/pagination';
 	import { goto } from '$app/navigation';
-	import { browser } from '$app/environment';
 	import ArrowDown from '$components/icons/ArrowDown.svelte';
 	import ArrowUp from '$components/icons/ArrowUp.svelte';
 	import SearchIcon from '$components/icons/SearchIcon.svelte';
@@ -33,60 +39,22 @@
 		? setMinutes(setHours(new Date(), 23), 0)
 		: new Date($fundsPageInfo.endDate);
 
-	$: currentUrl = browser ? document.location.href : '';
-
-	$: previousPage = () => {
-		if ($fundsPageInfo.page <= 1) return;
-
-		const prevUrl = new URL(currentUrl);
-
-		prevUrl.searchParams.set('page', `${$fundsPageInfo.page - 1}`);
-		goto(prevUrl);
-	};
-
-	$: nextPage = () => {
-		if ($fundsPageInfo.page >= $fundsPageInfo.totalPages) return;
-
-		const nextUrl = new URL(currentUrl);
-
-		nextUrl.searchParams.set('page', `${$fundsPageInfo.page + 1}`);
-
-		goto(nextUrl);
-	};
+	$: previousPage = () => goPreviousPage($fundsPageInfo.page);
+	$: nextPage = () => goNextPage($fundsPageInfo.page, $fundsPageInfo.totalPages);
+	$: dispatchSearch = () => doSearch(search);
+	$: changeTab = (filter: StatusFilter) => doChangeTab(filter);
 
 	$: changeDuration = () => {
 		const start = format(startDate, 'yyyy-MM-dd HH:mm');
 		const end = format(endDate, 'yyyy-MM-dd HH:mm');
 
-		const targetUrl = new URL(currentUrl);
+		const targetUrl = new URL(getCurrentUrl());
 
 		targetUrl.searchParams.set('startDate', start);
 		targetUrl.searchParams.set('endDate', end);
 		targetUrl.searchParams.delete('page');
 
 		goto(targetUrl.toString());
-	};
-
-	$: changeTab = (filter: StatusFilter) => {
-		const filterUrl = new URL(currentUrl);
-
-		filterUrl.searchParams.delete('page');
-
-		if (filter === 'all') {
-			filterUrl.searchParams.delete('filter');
-		} else {
-			filterUrl.searchParams.set('filter', filter);
-		}
-
-		goto(filterUrl);
-	};
-
-	$: dispatchSearch = () => {
-		const searchUrl = new URL(currentUrl);
-
-		searchUrl.searchParams.set('query', search);
-		searchUrl.searchParams.delete('page');
-		goto(searchUrl);
 	};
 </script>
 

--- a/src/lib/components/lists/HospitList.svelte
+++ b/src/lib/components/lists/HospitList.svelte
@@ -2,8 +2,12 @@
 	import { daysDiff, formatDateStringShortDay, formatFilterDate } from '$lib/utils/date';
 	import type { HospitStatusFilter as StatusFilter } from '$types';
 	import { hospitPageInfo } from '$store/hospit';
-	import { goto } from '$app/navigation';
-	import { browser } from '$app/environment';
+	import {
+		nextPage as goNextPage,
+		previousPage as goPreviousPage,
+		dispatchSearch as doSearch,
+		changeTab as doChangeTab
+	} from '$utils/pagination';
 	import AnimalIcon from '$components/display/animal/AnimalIcon.svelte';
 	import AgeDisplay from '$components/display/AgeDisplay.svelte';
 	import Grid from '$components/icons/Grid.svelte';
@@ -19,48 +23,10 @@
 	let page = $hospitPageInfo.page;
 	let statusFilter: StatusFilter = $hospitPageInfo.filter;
 
-	$: currentUrl = browser ? document.location.href : '';
-
-	$: nextPage = () => {
-		if ($hospitPageInfo.page === $hospitPageInfo.totalPages) return;
-
-		const nextUrl = new URL(currentUrl);
-
-		nextUrl.searchParams.set('page', `${$hospitPageInfo.page + 1}`);
-
-		goto(nextUrl);
-	};
-
-	$: previousPage = () => {
-		if ($hospitPageInfo.page === 1) return;
-
-		const prevUrl = new URL(currentUrl);
-
-		prevUrl.searchParams.set('page', `${$hospitPageInfo.page - 1}`);
-		goto(prevUrl);
-	};
-
-	$: dispatchSearch = () => {
-		const searchUrl = new URL(currentUrl);
-
-		searchUrl.searchParams.set('query', search);
-		searchUrl.searchParams.delete('page');
-		goto(searchUrl);
-	};
-
-	$: changeTab = (filter: StatusFilter) => {
-		const filterUrl = new URL(currentUrl);
-
-		filterUrl.searchParams.delete('page');
-
-		if (filter === 'all') {
-			filterUrl.searchParams.delete('filter');
-		} else {
-			filterUrl.searchParams.set('filter', filter);
-		}
-
-		goto(filterUrl);
-	};
+	$: nextPage = () => goNextPage($hospitPageInfo.page, $hospitPageInfo.totalPages);
+	$: previousPage = () => goPreviousPage($hospitPageInfo.page);
+	$: dispatchSearch = () => doSearch(search);
+	$: changeTab = (filter: StatusFilter) => doChangeTab(filter);
 </script>
 
 <div class="flex flex-col items-start justify-start xl:pl-14 w-full overflow-hidden">

--- a/src/lib/utils/pagination.ts
+++ b/src/lib/utils/pagination.ts
@@ -1,0 +1,53 @@
+import { goto } from '$app/navigation';
+import { browser } from '$app/environment';
+
+/**
+ * Get the current URL in the browser, or empty string during SSR.
+ */
+export const getCurrentUrl = (): string => (browser ? document.location.href : '');
+
+/**
+ * Navigate to the next page using URL search params.
+ */
+export const nextPage = (currentPage: number, totalPages: number): void => {
+	if (currentPage >= totalPages) return;
+	const url = new URL(getCurrentUrl());
+	url.searchParams.set('page', `${currentPage + 1}`);
+	goto(url);
+};
+
+/**
+ * Navigate to the previous page using URL search params.
+ */
+export const previousPage = (currentPage: number): void => {
+	if (currentPage <= 1) return;
+	const url = new URL(getCurrentUrl());
+	url.searchParams.set('page', `${currentPage - 1}`);
+	goto(url);
+};
+
+/**
+ * Dispatch a search query via URL search params, resetting to page 1.
+ */
+export const dispatchSearch = (query: string): void => {
+	const url = new URL(getCurrentUrl());
+	url.searchParams.set('query', query);
+	url.searchParams.delete('page');
+	goto(url);
+};
+
+/**
+ * Change the active filter tab via URL search params, resetting to page 1.
+ */
+export const changeTab = (tab: string): void => {
+	const url = new URL(getCurrentUrl());
+	url.searchParams.delete('page');
+
+	if (tab === 'all') {
+		url.searchParams.delete('filter');
+	} else {
+		url.searchParams.set('filter', tab);
+	}
+
+	goto(url);
+};


### PR DESCRIPTION
## Summary
- Extracted duplicated pagination, search, and tab-filtering logic from 5 list components into a shared `$utils/pagination` utility
- Replaced ~205 lines of repeated URL manipulation code with one-liner calls to shared functions

Closes #434
