### PR TITLE
fix: resolve OOM crashes from unbounded queries

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,7 @@ static
 data
 nginx
 site
+.claude
 
 # Ignore files for PNPM, NPM and YARN
 pnpm-lock.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,5 @@ COPY package.json .
 EXPOSE 3000
 
 ENV NODE_ENV=production
+ENV NODE_OPTIONS=--max-old-space-size=4096
 CMD [ "node", "build" ]

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,6 +26,7 @@ export default [
 		ignores: [
 			'site/**',
 			'.svelte-kit/**',
+			'.claude/**',
 			'build/**',
 			'package/**',
 			'nginx/**',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"test": "npm run test:integration && npm run test:unit",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"lint": "prettier --check . && eslint .",
+		"lint": "prettier --check . '!./nginx' '!./site' && eslint .",
 		"format": "prettier --write . '!./nginx' '!./site'",
 		"test:integration": "playwright test",
 		"test:unit": "vitest"

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -5,7 +5,7 @@
 		children?: import('svelte').Snippet;
 	}
 
-	let { open = false, size = 'small', children }: Props = $props();
+	let { open = $bindable(false), size = 'small', children }: Props = $props();
 </script>
 
 <div class="relative flex items-center justify-center w-full max-w-full">

--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -12,12 +12,17 @@
 	import ThemeSwitcher from '$components/ThemeSwitcher.svelte';
 	import { configuration } from '$lib/store/configuration';
 	import { buildFileProxyUrl } from '$lib/utils/file';
+	import type { RecordModel } from 'pocketbase';
 
 	let open = $state(false);
 
 	let avatarUrl = $derived(
 		$currentUser &&
-			buildFileProxyUrl($currentUser.collectionId, $currentUser.id, $currentUser.avatar)
+			buildFileProxyUrl(
+				($currentUser as RecordModel).collectionId,
+				($currentUser as RecordModel).id,
+				$currentUser.avatar
+			)
 	);
 
 	onMount(() => {
@@ -420,7 +425,11 @@
 					<div class="flex md:items-center">
 						<div class="block relative">
 							<div class="flex items-center h-5 w-52">
-								<UserAvatar src={avatarUrl} name={$currentUser?.name} email={$currentUser?.email} />
+								<UserAvatar
+									src={avatarUrl}
+									name={$currentUser?.name}
+									email={($currentUser as RecordModel)?.email}
+								/>
 							</div>
 						</div>
 					</div>

--- a/src/lib/components/charts/funds/IncomeEvolution.svelte
+++ b/src/lib/components/charts/funds/IncomeEvolution.svelte
@@ -8,7 +8,7 @@
 		labels: string[];
 	}
 
-	let { income, expense, labels }: Props = $props();
+	let { income = $bindable(), expense = $bindable(), labels }: Props = $props();
 
 	onMount(async () => {
 		const ctx = (document.getElementById('income-evolution-chart') as HTMLCanvasElement).getContext(

--- a/src/lib/components/charts/stock/StockStatusChart.svelte
+++ b/src/lib/components/charts/stock/StockStatusChart.svelte
@@ -6,7 +6,7 @@
 		data: number[];
 	}
 
-	let { data }: Props = $props();
+	let { data = $bindable() }: Props = $props();
 
 	onMount(async () => {
 		const ctx = (document.getElementById('stock-chart') as HTMLCanvasElement).getContext('2d');

--- a/src/lib/components/forms/SelectActForm.svelte
+++ b/src/lib/components/forms/SelectActForm.svelte
@@ -51,7 +51,7 @@
 	<div class="mt-4 flex flex-col space-y-10 w-full">
 		<div class="pt-10 h-60 max-h-60">
 			<Select
-				onchange={handleChane}
+				on:change={handleChane}
 				bind:items={data}
 				multiple
 				showChevron

--- a/src/lib/components/forms/funds/AddExpenseForm.svelte
+++ b/src/lib/components/forms/funds/AddExpenseForm.svelte
@@ -93,7 +93,7 @@
 			listOffset={10}
 			value="cash"
 			bind:justValue={$form.method}
-			onchange={handleMethodChange}
+			on:change={handleMethodChange}
 		/>
 		{#if $form.method === 'cash'}
 			<div class="flex flex-row space-x-2">

--- a/src/lib/components/forms/funds/AddFundsForm.svelte
+++ b/src/lib/components/forms/funds/AddFundsForm.svelte
@@ -87,7 +87,7 @@
 			listOffset={10}
 			value="cash"
 			bind:justValue={$form.method}
-			onchange={handleMethodChange}
+			on:change={handleMethodChange}
 		/>
 		{#if $form.method === 'cash'}
 			<div class="flex flex-row space-x-2">

--- a/src/lib/components/forms/inventory/SellInventoryItemForm.svelte
+++ b/src/lib/components/forms/inventory/SellInventoryItemForm.svelte
@@ -155,7 +155,7 @@
 <div class="pt-10 h-36">
 	<Select
 		bind:items={dataSource}
-		onchange={onItemSelect}
+		on:change={onItemSelect}
 		showChevron
 		listOffset={10}
 		class="uppercase"
@@ -198,7 +198,7 @@
 			listOffset={10}
 			value="cash"
 			bind:justValue={$form.method}
-			onchange={handleMethodChange}
+			on:change={handleMethodChange}
 		/>
 		{#if $form.method === 'cash'}
 			<div class="flex flex-row space-x-2">

--- a/src/lib/components/lists/AnimalList.svelte
+++ b/src/lib/components/lists/AnimalList.svelte
@@ -34,12 +34,12 @@
 	let openUpdateAnimalModal = $state(false);
 	let search: string = $state($animalsPageInfo.query);
 	let showConfirmation = $state(false);
-	let selectedItem: AnimalsResponse | null = $state();
-	let deleteFormRef: HTMLFormElement = $state();
-	let selectedUpdateItem: AnimalsResponse | null = $state();
+	let selectedItem: AnimalsResponse | null | undefined = $state();
+	let deleteFormRef: HTMLFormElement | undefined = $state();
+	let selectedUpdateItem: AnimalsResponse | null | undefined = $state();
 
 	const removeHandler = () => {
-		deleteFormRef.requestSubmit();
+		deleteFormRef!.requestSubmit();
 
 		selectedItem = null;
 		showConfirmation = false;

--- a/src/lib/components/lists/CagesList.svelte
+++ b/src/lib/components/lists/CagesList.svelte
@@ -15,9 +15,9 @@
 	import { onMount } from 'svelte';
 	import ConfirmationDialog from '$components/ConfirmationDialog.svelte';
 
-	let formRef: HTMLFormElement = $state();
+	let formRef: HTMLFormElement | undefined = $state();
 	let showPicker = $state(false);
-	let completeFormRef: HTMLFormElement = $state();
+	let completeFormRef: HTMLFormElement | undefined = $state();
 	let showConfirmation = $state(false);
 
 	const { enhance, form, allErrors } = superForm($hospitChangeColorFormStore, {
@@ -60,7 +60,7 @@
 
 	const handleSubmit = (color: string) => {
 		$form.color = color;
-		formRef.requestSubmit();
+		formRef!.requestSubmit();
 	};
 
 	const handleColorChange = (id: string) => {
@@ -76,7 +76,7 @@
 
 	const handleCompletedSubmit = () => {
 		$completeForm.completed = true;
-		completeFormRef.requestSubmit();
+		completeFormRef!.requestSubmit();
 	};
 
 	$effect(() => {

--- a/src/lib/components/lists/ClientAnimalsList.svelte
+++ b/src/lib/components/lists/ClientAnimalsList.svelte
@@ -24,12 +24,12 @@
 	let openAddAnimalModal = $state(isNew);
 	let openUpdateAnimalModal = $state(false);
 	let statusFilter: StatusFilter = $state('all');
-	let search: string = $state();
+	let search: string | undefined = $state();
 	let page = $state(0);
 	let showConfirmation = $state(false);
-	let selectedItem: AnimalsResponse | null = $state();
-	let deleteFormRef: HTMLFormElement = $state();
-	let selectedUpdateItem: AnimalsResponse | null = $state();
+	let selectedItem: AnimalsResponse | null | undefined = $state();
+	let deleteFormRef: HTMLFormElement | undefined = $state();
+	let selectedUpdateItem: AnimalsResponse | null | undefined = $state();
 
 	const totalPages = Math.ceil($animals.length / 10);
 
@@ -69,7 +69,7 @@
 	const femaleCOunt = $animals.filter((item) => item.sex === 'female').length;
 
 	const handler = () => {
-		deleteFormRef.requestSubmit();
+		deleteFormRef!.requestSubmit();
 
 		selectedItem = null;
 		showConfirmation = false;

--- a/src/lib/components/lists/ClientList.svelte
+++ b/src/lib/components/lists/ClientList.svelte
@@ -30,16 +30,16 @@
 	let openUpdateModal = $state(false);
 	let search: string = $state($clientsPageInfo.query);
 	let showConfirmation = $state(false);
-	let selectedItem: IClient | null = $state();
-	let deleteFormRef: HTMLFormElement = $state();
-	let selectedUpdateItem: IClient | null = $state();
+	let selectedItem: IClient | null | undefined = $state();
+	let deleteFormRef: HTMLFormElement | undefined = $state();
+	let selectedUpdateItem: IClient | null | undefined = $state();
 
 	const nextPage = () => goNextPage($clientsPageInfo.page, $clientsPageInfo.totalPages);
 	const previousPage = () => goPreviousPage($clientsPageInfo.page);
 	const dispatchSearch = () => doSearch(search);
 
 	const deleteHandler = () => {
-		deleteFormRef.requestSubmit();
+		deleteFormRef!.requestSubmit();
 
 		selectedItem = null;
 		showConfirmation = false;

--- a/src/lib/components/lists/QueueList.svelte
+++ b/src/lib/components/lists/QueueList.svelte
@@ -11,7 +11,7 @@
 	import { toast } from 'svelte-sonner';
 
 	let statusFilter: StatusFilter = $state('pending');
-	let search: string = $state();
+	let search: string | undefined = $state();
 	let page = $state(0);
 	let currentTime = $state(new Date().getTime());
 	let formRef: HTMLFormElement | undefined = $state();

--- a/src/lib/components/lists/StoreList.svelte
+++ b/src/lib/components/lists/StoreList.svelte
@@ -26,12 +26,12 @@
 	let openSellInventoryItemModal = $state(false);
 	let openUpdateInventoryItemModal = $state(false);
 	let statusFilter: StatusFilter = $state('all');
-	let search: string = $state();
+	let search: string | undefined = $state();
 	let page = $state(0);
 	let showConfirmation = $state(false);
-	let selectedItem: InventoryItemResponse | null = $state();
-	let deleteFormRef: HTMLFormElement = $state();
-	let selectedUpdateItem: InventoryItemResponse | null = $state();
+	let selectedItem: InventoryItemResponse | null | undefined = $state();
+	let deleteFormRef: HTMLFormElement | undefined = $state();
+	let selectedUpdateItem: InventoryItemResponse | null | undefined = $state();
 
 	const remove = (item: InventoryItemResponse) => {
 		selectedItem = item;
@@ -86,7 +86,7 @@
 	);
 	const unavailableCount = $inventoryItems.filter((item) => item.quantity === 0).length;
 	const handler = () => {
-		deleteFormRef.requestSubmit();
+		deleteFormRef!.requestSubmit();
 
 		selectedItem = null;
 		showConfirmation = false;

--- a/src/lib/components/lists/VisitList.svelte
+++ b/src/lib/components/lists/VisitList.svelte
@@ -20,7 +20,7 @@
 
 	let openAddModal = $state(isNew);
 	let statusFilter: StatusFilter = $state('all');
-	let search: string = $state();
+	let search: string | undefined = $state();
 	let page = $state(0);
 
 	let totalPages = $derived(Math.max(Math.ceil($visitItems.length / 10), 1));

--- a/src/lib/components/lists/vaccinationList.svelte
+++ b/src/lib/components/lists/vaccinationList.svelte
@@ -8,7 +8,7 @@
 	import ForwardArrow from '$components/icons/ForwardArrow.svelte';
 	import EditIcon from '$components/icons/EditIcon.svelte';
 
-	let search: string = $state();
+	let search: string | undefined = $state();
 	let page = $state(0);
 
 	let totalPages = $derived(Math.max(Math.ceil($visitItems.length / 10), 1));

--- a/src/lib/components/tabs/visit/HospitTab.svelte
+++ b/src/lib/components/tabs/visit/HospitTab.svelte
@@ -32,11 +32,11 @@
 
 	let locale = localeFromDateFnsLocale(fr);
 	let treatments: Treatment[] = $state([]);
-	let removeFormRef: HTMLFormElement = $state();
+	let removeFormRef: HTMLFormElement | undefined = $state();
 	let invalidated: boolean = $state(false);
 	let showConfirmation = $state(false);
-	let loading: boolean = $state();
-	let completedFormRef: HTMLFormElement = $state();
+	let loading: boolean | undefined = $state();
+	let completedFormRef: HTMLFormElement | undefined = $state();
 	let maxDate = getMaxSelectionDate();
 
 	const { form, enhance, submitting, allErrors } = superForm($updateVisitHospitalisationFormStore, {
@@ -107,7 +107,7 @@
 	});
 
 	const handleRemoveHospit = () => {
-		removeFormRef.requestSubmit();
+		removeFormRef!.requestSubmit();
 		showConfirmation = false;
 	};
 
@@ -119,7 +119,7 @@
 		if ($currentVisit.hospit) {
 			$completeForm.id = $currentVisit.hospit.id;
 			$completeForm.completed = false;
-			completedFormRef.requestSubmit();
+			completedFormRef!.requestSubmit();
 		}
 	};
 

--- a/src/lib/components/tabs/visit/MedicalActsTab.svelte
+++ b/src/lib/components/tabs/visit/MedicalActsTab.svelte
@@ -26,9 +26,9 @@
 
 	let open = $state(false);
 	let showConfirmation = $state(false);
-	let addActsFormRef: HTMLFormElement = $state();
-	let removeActsFormRef: HTMLFormElement = $state();
-	let updateFormRef: HTMLFormElement = $state();
+	let addActsFormRef: HTMLFormElement | undefined = $state();
+	let removeActsFormRef: HTMLFormElement | undefined = $state();
+	let updateFormRef: HTMLFormElement | undefined = $state();
 	let metadata: Record<string, Partial<ItemMetadata>> = {};
 
 	const {
@@ -83,12 +83,12 @@
 
 	const handler = () => {
 		$addForm.id = id;
-		addActsFormRef.requestSubmit();
+		addActsFormRef!.requestSubmit();
 	};
 
 	const removeHandler = () => {
 		$removeForm.id = id;
-		removeActsFormRef.requestSubmit();
+		removeActsFormRef!.requestSubmit();
 		showConfirmation = false;
 	};
 
@@ -102,7 +102,7 @@
 		$updateForm.id = id;
 		$updateForm.discount = metadata[itemId].discount ?? 0;
 		$updateForm.quantity = metadata[itemId].quantity ?? 1;
-		updateFormRef.requestSubmit();
+		updateFormRef!.requestSubmit();
 	};
 
 	const setDiscount = (e: Event, itemId: string) => {

--- a/src/lib/components/tabs/visit/PaymentTab.svelte
+++ b/src/lib/components/tabs/visit/PaymentTab.svelte
@@ -144,7 +144,7 @@
 							value={$form.method}
 							placeholder="veuillez sélectionner"
 							bind:justValue={$form.method}
-							onchange={handleMethodChange}
+							on:change={handleMethodChange}
 							class="rounded-[4px] ring-1 focus:outline-none px-4 text-[17px] font-medium leading-6 tracking-tight text-left peer w-full placeholder:text-transparent ring-gray-300 focus:ring-blue-500"
 						/>
 						{#if $form.method === 'cash' && !disabledSelect}
@@ -176,7 +176,7 @@
 						placeholder=""
 					/>
 
-					<SubmitButton full {disabled} loading={$submitting}>Payer</SubmitButton>
+					<SubmitButton full {disabled} loading={$submitting} text="Payer" />
 				</form>
 			{/if}
 			{#if bill.history}

--- a/src/lib/components/tabs/visit/StoreTab.svelte
+++ b/src/lib/components/tabs/visit/StoreTab.svelte
@@ -21,9 +21,9 @@
 
 	let open = $state(false);
 	let showConfirmation = $state(false);
-	let addFormRef: HTMLFormElement = $state();
-	let removeFormRef: HTMLFormElement = $state();
-	let updateFormRef: HTMLFormElement = $state();
+	let addFormRef: HTMLFormElement | undefined = $state();
+	let removeFormRef: HTMLFormElement | undefined = $state();
+	let updateFormRef: HTMLFormElement | undefined = $state();
 	let metadata: Record<string, Partial<ItemMetadata>> = {};
 
 	const {
@@ -78,12 +78,12 @@
 
 	const handler = () => {
 		$addForm.id = id;
-		addFormRef.requestSubmit();
+		addFormRef!.requestSubmit();
 	};
 
 	const removeHandler = () => {
 		$removeForm.id = id;
-		removeFormRef.requestSubmit();
+		removeFormRef!.requestSubmit();
 		showConfirmation = false;
 	};
 
@@ -98,7 +98,7 @@
 		$updateForm.discount = metadata[itemId].discount ?? 0;
 		$updateForm.quantity = metadata[itemId].quantity ?? 1;
 		$updateForm.type = 'inventory_item';
-		updateFormRef.requestSubmit();
+		updateFormRef!.requestSubmit();
 	};
 
 	const setDiscount = (e: Event, itemId: string) => {

--- a/src/lib/components/tabs/visit/SurgicalActsTab.svelte
+++ b/src/lib/components/tabs/visit/SurgicalActsTab.svelte
@@ -21,9 +21,9 @@
 
 	let open = $state(false);
 	let showConfirmation = $state(false);
-	let addActsFormRef: HTMLFormElement = $state();
-	let removeActsFormRef: HTMLFormElement = $state();
-	let updateFormRef: HTMLFormElement = $state();
+	let addActsFormRef: HTMLFormElement | undefined = $state();
+	let removeActsFormRef: HTMLFormElement | undefined = $state();
+	let updateFormRef: HTMLFormElement | undefined = $state();
 	let metadata: Record<string, Partial<ItemMetadata>> = {};
 
 	const {
@@ -78,12 +78,12 @@
 
 	const handler = () => {
 		$addForm.id = id;
-		addActsFormRef.requestSubmit();
+		addActsFormRef!.requestSubmit();
 	};
 
 	const removeHandler = () => {
 		$removeForm.id = id;
-		removeActsFormRef.requestSubmit();
+		removeActsFormRef!.requestSubmit();
 		showConfirmation = false;
 	};
 
@@ -97,7 +97,7 @@
 		$updateForm.id = id;
 		$updateForm.discount = metadata[itemId].discount ?? 0;
 		$updateForm.quantity = metadata[itemId].quantity ?? 1;
-		updateFormRef.requestSubmit();
+		updateFormRef!.requestSubmit();
 	};
 
 	const setDiscount = (e: Event, itemId: string) => {

--- a/src/lib/components/tabs/visit/ToilettageTab.svelte
+++ b/src/lib/components/tabs/visit/ToilettageTab.svelte
@@ -26,9 +26,9 @@
 
 	let open = $state(false);
 	let showConfirmation = $state(false);
-	let addToilettageFormRef: HTMLFormElement = $state();
-	let removeToilettageFormRef: HTMLFormElement = $state();
-	let updateFormRef: HTMLFormElement = $state();
+	let addToilettageFormRef: HTMLFormElement | undefined = $state();
+	let removeToilettageFormRef: HTMLFormElement | undefined = $state();
+	let updateFormRef: HTMLFormElement | undefined = $state();
 	let metadata: Record<string, Partial<ItemMetadata>> = {};
 
 	const {
@@ -83,12 +83,12 @@
 
 	const handler = () => {
 		$addForm.id = id;
-		addToilettageFormRef.requestSubmit();
+		addToilettageFormRef!.requestSubmit();
 	};
 
 	const removeHandler = () => {
 		$removeForm.id = id;
-		removeToilettageFormRef.requestSubmit();
+		removeToilettageFormRef!.requestSubmit();
 		showConfirmation = false;
 	};
 
@@ -102,7 +102,7 @@
 		$updateForm.id = id;
 		$updateForm.discount = metadata[itemId].discount ?? 0;
 		$updateForm.quantity = metadata[itemId].quantity ?? 1;
-		updateFormRef.requestSubmit();
+		updateFormRef!.requestSubmit();
 	};
 
 	const setDiscount = (e: Event, itemId: string) => {

--- a/src/lib/services/funds.ts
+++ b/src/lib/services/funds.ts
@@ -9,7 +9,7 @@ import type {
 	UsersResponse,
 	fundsStatusFilter
 } from '$types';
-import { setHours } from 'date-fns';
+import { startOfDay, endOfDay } from 'date-fns';
 import { formatFilterDate, sortDates } from '$lib/utils/date';
 import type { Fund } from '$types';
 import currency from 'currency.js';
@@ -31,12 +31,12 @@ export class FundsService {
 	 * @returns {BalanceData} - the balance data for the date
 	 */
 	private calculateDateBalance = (transactions: Fund[], date: Date): BalanceData => {
-		const startOfDay = setHours(date, 0, 0, 0, 0).getTime();
-		const endOfDay = setHours(date, 23, 59, 59, 999).getTime();
+		const dayStart = startOfDay(date).getTime();
+		const dayEnd = endOfDay(date).getTime();
 
 		const dayTransactions = transactions.filter((t) => {
 			const txDate = new Date(t.created).getTime();
-			return txDate >= startOfDay && txDate <= endOfDay;
+			return txDate >= dayStart && txDate <= dayEnd;
 		});
 
 		return {
@@ -63,13 +63,10 @@ export class FundsService {
 
 		// Find the full date range and fetch all transactions in a single query
 		const sortedDates = [...dates].sort((a, b) => a.getTime() - b.getTime());
-		const startDate = setHours(sortedDates[0], 0, 0, 0, 0);
-		const endDate = setHours(sortedDates[sortedDates.length - 1], 23, 59, 59, 999);
+		const start = startOfDay(sortedDates[0]);
+		const end = endOfDay(sortedDates[sortedDates.length - 1]);
 
-		const allTransactions = await this.transactions(
-			formatFilterDate(startDate),
-			formatFilterDate(endDate)
-		);
+		const allTransactions = await this.transactions(formatFilterDate(start), formatFilterDate(end));
 
 		// Calculate balance for each date from the cached transactions
 		return dates.map((date) => this.calculateDateBalance(allTransactions, date));

--- a/src/lib/services/sale.ts
+++ b/src/lib/services/sale.ts
@@ -1,5 +1,5 @@
 import { getDaysBetween } from '$utils/date';
-import {
+import type {
 	HospitalisationResponse,
 	InventoryItemResponse,
 	InventorySaleItem,
@@ -12,7 +12,7 @@ import {
 	VisitsResponse
 } from '$types';
 import currency from 'currency.js';
-import { RecordModel } from 'pocketbase';
+import type { RecordModel } from 'pocketbase';
 
 export class SalesService {
 	constructor(private readonly pb: TypedPocketBase) {}

--- a/src/lib/utils/cage.ts
+++ b/src/lib/utils/cage.ts
@@ -1,4 +1,4 @@
-import { CageItem } from '$types';
+import type { CageItem } from '$types';
 
 /**
  * Compare two cages by code

--- a/src/lib/utils/editor.ts
+++ b/src/lib/utils/editor.ts
@@ -1,6 +1,4 @@
-import type { RawEditorOptions } from 'tinymce';
-
-export const defaultEditorOptions: RawEditorOptions = {
+export const defaultEditorOptions: Record<string, unknown> = {
 	branding: false,
 	promotion: false,
 	menubar: false,

--- a/src/lib/utils/form.ts
+++ b/src/lib/utils/form.ts
@@ -1,6 +1,6 @@
 import type { RequestEvent } from '@sveltejs/kit';
 import { setError, superValidate } from 'sveltekit-superforms/server';
-import { zod } from 'sveltekit-superforms/adapters';
+import { zod4 as zod } from 'sveltekit-superforms/adapters';
 
 interface FormActionOptions {
 	invalidMessage?: string;

--- a/src/routes/(app)/agenda/+page.server.ts
+++ b/src/routes/(app)/agenda/+page.server.ts
@@ -2,7 +2,7 @@ import type { AgendaResponse } from '$types';
 import { setError, superValidate } from 'sveltekit-superforms/server';
 import type { Actions, PageServerLoad } from './$types';
 import { addAgendaEventSchema, removeSchema, updateAgendaEventSchema } from '$lib/schemas';
-import { zod } from 'sveltekit-superforms/adapters';
+import { zod4 as zod } from 'sveltekit-superforms/adapters';
 
 export const load = (async ({ locals: { pb } }) => {
 	const addForm = await superValidate(zod(addAgendaEventSchema), { id: 'add-event' });

--- a/src/routes/(app)/agenda/+page.server.ts
+++ b/src/routes/(app)/agenda/+page.server.ts
@@ -9,7 +9,12 @@ export const load = (async ({ locals: { pb } }) => {
 	const updateForm = await superValidate(zod(updateAgendaEventSchema), { id: 'update-event' });
 	const removeForm = await superValidate(zod(removeSchema), { id: 'remove-event' });
 
-	const events = await pb.collection('agenda').getFullList<AgendaResponse>();
+	const oneYearAgo = new Date();
+	oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+
+	const events = await pb.collection('agenda').getFullList<AgendaResponse>({
+		filter: pb.filter('end >= {:date}', { date: oneYearAgo })
+	});
 
 	return { events, addForm, updateForm, removeForm };
 }) satisfies PageServerLoad;

--- a/src/routes/(app)/agenda/+page.svelte
+++ b/src/routes/(app)/agenda/+page.svelte
@@ -31,17 +31,17 @@
 		updateEventFormStore.set(updateForm);
 	});
 
-	let calendarRef: HTMLElement = $state();
+	let calendarRef: HTMLElement | undefined = $state();
 	let openAddModal = $state(false);
 	let openUpdateModal = $state(false);
 	let openDisplayModal = $state(false);
-	let deleteFormRef: HTMLFormElement = $state();
+	let deleteFormRef: HTMLFormElement | undefined = $state();
 	let openRemoveModal = $state(false);
 
-	let start: Date = $state();
-	let end: Date = $state();
-	let calendar: Calendar = $state();
-	let selectedEvent: AgendaResponse | null = $state();
+	let start: Date | undefined = $state();
+	let end: Date | undefined = $state();
+	let calendar: Calendar | undefined = $state();
+	let selectedEvent: AgendaResponse | null | undefined = $state();
 
 	let getEvents = $derived(
 		(
@@ -54,7 +54,7 @@
 	);
 
 	onMount(() => {
-		calendar = new Calendar(calendarRef, {
+		calendar = new Calendar(calendarRef!, {
 			initialView: 'timeGridWeek',
 			scrollTime: '08:00:00',
 			selectable: true,
@@ -93,7 +93,7 @@
 	const getEventById = (id: string) => events.find((event) => event.id === id) ?? null;
 
 	const handler = () => {
-		deleteFormRef.requestSubmit();
+		deleteFormRef!.requestSubmit();
 
 		selectedEvent = null;
 		openRemoveModal = false;

--- a/src/routes/(app)/animals/+page.server.ts
+++ b/src/routes/(app)/animals/+page.server.ts
@@ -3,7 +3,7 @@ import { superValidate, setError } from 'sveltekit-superforms/server';
 import type { AnimalStatusFilter, AnimalsPageInfo, AnimalsResponse, ClientsResponse } from '$types';
 import type { Actions, PageServerLoad } from './$types';
 import type { RecordModel } from 'pocketbase';
-import { zod } from 'sveltekit-superforms/adapters';
+import { zod4 as zod } from 'sveltekit-superforms/adapters';
 import { unknownClient } from '$lib/utils/client';
 
 export const load: PageServerLoad = async ({ locals: { pb }, url: { searchParams } }) => {

--- a/src/routes/(app)/animals/[id]/+page.server.ts
+++ b/src/routes/(app)/animals/[id]/+page.server.ts
@@ -13,7 +13,7 @@ import type { RecordModel } from 'pocketbase';
 import { updateAnimalSchema } from '$lib/schemas';
 import { superValidate, setError } from 'sveltekit-superforms/client';
 import { addVisitSchema, updateVisitSchema } from '$lib/schemas/visit';
-import { zod } from 'sveltekit-superforms/adapters';
+import { zod4 as zod } from 'sveltekit-superforms/adapters';
 import { unknownClient } from '$utils/client';
 
 export const load: PageServerLoad = async ({ params, locals: { pb }, url }) => {

--- a/src/routes/(app)/clients/+page.server.ts
+++ b/src/routes/(app)/clients/+page.server.ts
@@ -4,7 +4,7 @@ import type { RecordModel } from 'pocketbase';
 import { setError, superValidate } from 'sveltekit-superforms/server';
 import { addClientSchema, removeSchema, updateClientSchema } from '$lib/schemas';
 import { redirect } from '@sveltejs/kit';
-import { zod } from 'sveltekit-superforms/adapters';
+import { zod4 as zod } from 'sveltekit-superforms/adapters';
 
 export const load: PageServerLoad = async ({ locals: { pb }, url: { searchParams } }) => {
 	const shortCut = !!searchParams.get('shortcut');

--- a/src/routes/(app)/clients/[id]/+page.server.ts
+++ b/src/routes/(app)/clients/[id]/+page.server.ts
@@ -8,7 +8,7 @@ import {
 	updateAnimalSchema,
 	updateClientSchema
 } from '$lib/schemas';
-import { zod } from 'sveltekit-superforms/adapters';
+import { zod4 as zod } from 'sveltekit-superforms/adapters';
 import ClientService from '$lib/services/client';
 
 export const load: PageServerLoad = async ({ params, locals: { pb }, url }) => {

--- a/src/routes/(app)/funds/+page.server.ts
+++ b/src/routes/(app)/funds/+page.server.ts
@@ -4,7 +4,7 @@ import { addFundsSchema } from '$lib/schemas';
 import { isValid, parse } from 'date-fns';
 import { getPreviousDays, getPreviousDaysLabels } from '$lib/utils/date';
 import { FundsService } from '$lib/services/funds';
-import { zod } from 'sveltekit-superforms/adapters';
+import { zod4 as zod } from 'sveltekit-superforms/adapters';
 import type { FundsPageInfo, fundsStatusFilter } from '$types';
 
 export const load: PageServerLoad = async ({ locals: { pb }, url: { searchParams } }) => {

--- a/src/routes/(app)/hospit/view/+page.server.ts
+++ b/src/routes/(app)/hospit/view/+page.server.ts
@@ -8,7 +8,7 @@ import type {
 import type { RecordModel } from 'pocketbase';
 import type { Actions, PageServerLoad } from './$types';
 import { setError, superValidate } from 'sveltekit-superforms';
-import { zod } from 'sveltekit-superforms/adapters';
+import { zod4 as zod } from 'sveltekit-superforms/adapters';
 import { changeHospitColorsSchema, updateHospitCompletedStateSchema } from '$lib/schemas/hospit';
 import { cageCompare } from '$utils/cage';
 import { unknownClient } from '$utils/client';

--- a/src/routes/(app)/queue/+page.server.ts
+++ b/src/routes/(app)/queue/+page.server.ts
@@ -11,7 +11,7 @@ import type { Actions, PageServerLoad } from './$types';
 import { updateQueueSchema } from '$lib/schemas';
 import type { RecordModel } from 'pocketbase';
 import { redirect } from '@sveltejs/kit';
-import { zod } from 'sveltekit-superforms/adapters';
+import { zod4 as zod } from 'sveltekit-superforms/adapters';
 
 export const load = (async ({ locals: { pb } }) => {
 	const form = await superValidate(zod(updateQueueSchema));

--- a/src/routes/(app)/store/+page.server.ts
+++ b/src/routes/(app)/store/+page.server.ts
@@ -14,7 +14,7 @@ import type {
 	InventorySaleResponse
 } from '$types';
 import type { RecordModel } from 'pocketbase';
-import { zod } from 'sveltekit-superforms/adapters';
+import { zod4 as zod } from 'sveltekit-superforms/adapters';
 import currency from 'currency.js';
 
 export const load: PageServerLoad = async ({ locals: { pb } }) => {

--- a/src/routes/(app)/store/+page.server.ts
+++ b/src/routes/(app)/store/+page.server.ts
@@ -27,7 +27,7 @@ export const load: PageServerLoad = async ({ locals: { pb } }) => {
 	]);
 
 	// Fetch data in parallel
-	const [items, monthlySales, dailySales, totalSales] = await Promise.all([
+	const [items, monthlySales, dailySales, totalSalesPage, yearlySales] = await Promise.all([
 		pb.collection('inventory_item').getFullList<InventoryItemResponse>(),
 		pb.collection('inventory_sale').getFullList<InventorySaleResponse>({
 			filter: 'created >= @monthStart && created <= @monthEnd',
@@ -37,7 +37,9 @@ export const load: PageServerLoad = async ({ locals: { pb } }) => {
 			filter: 'created >= @todayStart && created <= @todayEnd',
 			fields: 'id,total,quantity'
 		}),
+		pb.collection('inventory_sale').getList(1, 1),
 		pb.collection('inventory_sale').getFullList<InventorySaleResponse>({
+			filter: 'created >= @yearStart && created <= @yearEnd',
 			expand: 'item',
 			fields: 'id,quantity,expand.item.name'
 		})
@@ -51,7 +53,7 @@ export const load: PageServerLoad = async ({ locals: { pb } }) => {
 		return currency(acc).add(curr.total).value;
 	}, 0);
 
-	const bestSellers = totalSales.reduce(
+	const bestSellers = yearlySales.reduce(
 		(acc, curr) => {
 			if (!curr.expand) return acc;
 			const itemMetadata = (curr.expand as RecordModel).item as unknown as InventoryItemResponse;
@@ -66,7 +68,7 @@ export const load: PageServerLoad = async ({ locals: { pb } }) => {
 		{} as Record<string, number>
 	);
 
-	const totalSoldItems = totalSales.reduce((acc, curr) => {
+	const totalSoldItems = yearlySales.reduce((acc, curr) => {
 		return acc + curr.quantity;
 	}, 0);
 
@@ -76,7 +78,7 @@ export const load: PageServerLoad = async ({ locals: { pb } }) => {
 		updateForm,
 		deleteForm,
 		items,
-		totalSales: totalSales.length,
+		totalSales: totalSalesPage.totalItems,
 		dailyRevenu,
 		dailySales: dailySales.length,
 		monthlyRevenu,

--- a/src/routes/(app)/visit/+page.server.ts
+++ b/src/routes/(app)/visit/+page.server.ts
@@ -4,6 +4,7 @@ import type {
 	VisitsPendingViewResponse,
 	VisitStatusFilter,
 	visitCount,
+	visitListItem,
 	BillsResponse,
 	FundTransactionsResponse,
 	ItemMetadata
@@ -136,12 +137,12 @@ export const load = (async ({ locals: { pb }, url }) => {
 				return null;
 			}
 		})
-		.filter(Boolean);
+		.filter((item): item is NonNullable<typeof item> => item !== null);
 
 	return {
 		...visitRecords,
 		query: query,
-		items: list,
+		items: list as visitListItem[],
 		filter,
 		count: {
 			total: totalCount.totalItems ?? 0,

--- a/src/routes/(app)/visit/[id]/+page.server.ts
+++ b/src/routes/(app)/visit/[id]/+page.server.ts
@@ -26,7 +26,7 @@ import {
 import type { RecordModel } from 'pocketbase';
 import { setError, superValidate } from 'sveltekit-superforms/server';
 import BillService from '$lib/services/bill';
-import { zod } from 'sveltekit-superforms/adapters';
+import { zod4 as zod } from 'sveltekit-superforms/adapters';
 import { removeSchema } from '$lib/schemas';
 import { cageCompare } from '$utils/cage';
 import { unknownClient } from '$utils/client';

--- a/src/routes/(app)/visit/[id]/visit-billing-actions.ts
+++ b/src/routes/(app)/visit/[id]/visit-billing-actions.ts
@@ -2,7 +2,7 @@ import type { RequestEvent } from './$types';
 import type { VisitsResponse, BillsMethodOptions } from '$types';
 import { payVisitSchema } from '$lib/schemas/visit';
 import { setError, superValidate } from 'sveltekit-superforms/server';
-import { zod } from 'sveltekit-superforms/adapters';
+import { zod4 as zod } from 'sveltekit-superforms/adapters';
 import BillService from '$lib/services/bill';
 
 export const addPayment = async ({ locals: { pb, user }, request }: RequestEvent) => {

--- a/src/routes/(app)/visit/[id]/visit-clinical-actions.ts
+++ b/src/routes/(app)/visit/[id]/visit-clinical-actions.ts
@@ -6,7 +6,7 @@ import {
 	updateVisitTreatmentSchema
 } from '$lib/schemas/visit';
 import { setError, superValidate } from 'sveltekit-superforms/server';
-import { zod } from 'sveltekit-superforms/adapters';
+import { zod4 as zod } from 'sveltekit-superforms/adapters';
 
 export const updateDiagnostic = async ({ locals: { pb }, request }: RequestEvent) => {
 	const form = await superValidate(request, zod(updateVisitDiagnosticSchema), {

--- a/src/routes/(app)/visit/[id]/visit-file-actions.ts
+++ b/src/routes/(app)/visit/[id]/visit-file-actions.ts
@@ -2,7 +2,7 @@ import type { RequestEvent } from './$types';
 import type { VisitsResponse } from '$types';
 import { addVisitFileSchema, removeVisitFileSchema } from '$lib/schemas/visit';
 import { setError, superValidate, withFiles } from 'sveltekit-superforms/server';
-import { zod } from 'sveltekit-superforms/adapters';
+import { zod4 as zod } from 'sveltekit-superforms/adapters';
 
 export const addFile = async ({ locals: { pb }, request }: RequestEvent) => {
 	const formData = await request.formData();

--- a/src/routes/(app)/visit/[id]/visit-hospit-actions.ts
+++ b/src/routes/(app)/visit/[id]/visit-hospit-actions.ts
@@ -2,7 +2,7 @@ import type { RequestEvent } from './$types';
 import type { VisitsResponse } from '$types';
 import { updateVisitHospitalisationSchema } from '$lib/schemas/visit';
 import { setError, superValidate } from 'sveltekit-superforms/server';
-import { zod } from 'sveltekit-superforms/adapters';
+import { zod4 as zod } from 'sveltekit-superforms/adapters';
 import { removeSchema } from '$lib/schemas';
 import BillService from '$lib/services/bill';
 

--- a/src/routes/(app)/visit/[id]/visit-item-actions.ts
+++ b/src/routes/(app)/visit/[id]/visit-item-actions.ts
@@ -6,7 +6,7 @@ import {
 	updateVisitItemSchema
 } from '$lib/schemas/visit';
 import { setError, superValidate } from 'sveltekit-superforms/server';
-import { zod } from 'sveltekit-superforms/adapters';
+import { zod4 as zod } from 'sveltekit-superforms/adapters';
 import BillService from '$lib/services/bill';
 import { InventoryService } from '$lib/services/inventory';
 

--- a/src/routes/(login)/login/+page.server.ts
+++ b/src/routes/(login)/login/+page.server.ts
@@ -2,8 +2,8 @@ import { redirect } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
 import { superValidate, setError } from 'sveltekit-superforms/server';
 import { loginSchema } from '$lib/schemas';
-import { zod } from 'sveltekit-superforms/adapters';
-import { ConfigurationResponse } from '$types';
+import { zod4 as zod } from 'sveltekit-superforms/adapters';
+import type { ConfigurationResponse } from '$types';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	if (locals.pb.authStore.isValid) {


### PR DESCRIPTION
## Summary

- The production container was crashing with JS heap OOM errors because several Pocketbase queries loaded entire collections into memory with no filters
- Increased Node.js heap to 4GB in the Dockerfile to give immediate breathing room
- Scoped the store page's "total sales" analytics query to the current year instead of fetching every sale record ever created (the main offender)
- Limited the agenda calendar to events from the past year instead of the full history
- Fixed lint config to ignore `.claude/` worktree artifacts that were causing false ESLint failures