### PR TITLE
Fix SSR crashes and Svelte 5 reactivity issues

### DIFF
--- a/src/lib/components/forms/animals/updateAnimalForm.svelte
+++ b/src/lib/components/forms/animals/updateAnimalForm.svelte
@@ -10,6 +10,7 @@
 	import { animalTypeList } from '$utils/animal';
 	import { toast } from 'svelte-sonner';
 	import EditIcon from '$components/icons/EditIcon.svelte';
+	import { untrack } from 'svelte';
 
 	interface Props {
 		open?: boolean;
@@ -36,37 +37,24 @@
 	let deceased = $state($currentAnimal.deceased);
 
 	$effect(() => {
-		$form.id = $currentAnimal.id;
-	});
-	$effect(() => {
-		$form.birthday = new Date(birthday);
-	});
-	$effect(() => {
-		$form.name = $currentAnimal.name;
-	});
-	$effect(() => {
-		$form.sex = $currentAnimal.sex;
-	});
-	$effect(() => {
-		$form.type = $currentAnimal.type;
-	});
-	$effect(() => {
-		$form.weight = $currentAnimal.weight;
-	});
-	$effect(() => {
-		$form.color = $currentAnimal.color;
-	});
-	$effect(() => {
-		$form.breed = $currentAnimal.breed;
-	});
-	$effect(() => {
-		$form.deceased = deceased;
-	});
-	$effect(() => {
-		$form.identifier = $currentAnimal.identifier;
-	});
-	$effect(() => {
-		$form.deathdate = $form.deceased ? new Date(deathdate) : undefined;
+		const animal = $currentAnimal;
+		const bd = birthday;
+		const dd = deathdate;
+		const dec = deceased;
+
+		untrack(() => {
+			$form.id = animal.id;
+			$form.birthday = new Date(bd);
+			$form.name = animal.name;
+			$form.sex = animal.sex;
+			$form.type = animal.type;
+			$form.weight = animal.weight;
+			$form.color = animal.color;
+			$form.breed = animal.breed;
+			$form.deceased = dec;
+			$form.identifier = animal.identifier;
+			$form.deathdate = dec ? new Date(dd) : undefined;
+		});
 	});
 
 	$effect(() => {
@@ -144,13 +132,7 @@
 		required={false}
 	/>
 	<div class="mt-4 w-full">
-		<input
-			type="checkbox"
-			id="deceased"
-			bind:value={deceased}
-			bind:checked={deceased}
-			class="hidden peer"
-		/>
+		<input type="checkbox" id="deceased" bind:checked={deceased} class="hidden peer" />
 		<label
 			for="deceased"
 			class="inline-flex items-center justify-between p-5 w-full text-gray-500 bg-white border-2 border-gray-200 rounded-lg cursor-pointer peer-checked:border-red-600 hover:text-gray-600 peer-checked:text-gray-600 hover:bg-gray-50"

--- a/src/lib/components/tabs/visit/InfoTab.svelte
+++ b/src/lib/components/tabs/visit/InfoTab.svelte
@@ -10,6 +10,7 @@
 	import Vaccination from '$components/icons/Vaccination.svelte';
 	import MagnifierGlass from '$components/icons/MagnifierGlass.svelte';
 	import { toast } from 'svelte-sonner';
+	import { untrack } from 'svelte';
 
 	const { enhance, form, submitting, allErrors } = superForm($updateVisitFormStore, {
 		taintedMessage: null,
@@ -23,22 +24,15 @@
 	});
 
 	$effect(() => {
-		$form.motif = $currentVisit.motif;
-	});
-	$effect(() => {
-		$form.id = $currentVisit.id;
-	});
-	$effect(() => {
-		$form.doctor = $currentVisit.doctor;
-	});
-	$effect(() => {
-		$form.visit_price = $currentVisit.visit_price;
-	});
-	$effect(() => {
-		$form.control = $currentVisit.control;
-	});
-	$effect(() => {
-		$form.vaccination = $currentVisit.vaccination;
+		const visit = $currentVisit;
+		untrack(() => {
+			$form.id = visit.id;
+			$form.motif = visit.motif;
+			$form.doctor = visit.doctor;
+			$form.visit_price = visit.visit_price;
+			$form.control = visit.control;
+			$form.vaccination = visit.vaccination;
+		});
 	});
 	let doctors = $derived(
 		$doctorList.map((doctor) => ({
@@ -92,13 +86,7 @@
 					/>
 				</div>
 				<div class="flex items-center justify-end flex-col w-full pt-5 lg:pt-0">
-					<input
-						bind:checked={$form.control}
-						type="checkbox"
-						id="control"
-						value={$form.control}
-						class="hidden peer"
-					/>
+					<input bind:checked={$form.control} type="checkbox" id="control" class="hidden peer" />
 					<label
 						for="control"
 						class="inline-flex items-center justify-between w-full p-5 py-3 text-gray-500 bg-white border-2 border-gray-100 rounded-lg cursor-pointer peer-checked:border-emerald-600 hover:text-gray-600 peer-checked:text-gray-800 hover:bg-gray-50 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-300 dark:peer-checked:text-gray-200"
@@ -114,7 +102,6 @@
 						bind:checked={$form.vaccination}
 						type="checkbox"
 						id="vaccination"
-						value={$form.vaccination}
 						class="hidden peer"
 					/>
 					<label

--- a/src/lib/components/tabs/visit/PaymentTab.svelte
+++ b/src/lib/components/tabs/visit/PaymentTab.svelte
@@ -13,6 +13,7 @@
 	import { toast } from 'svelte-sonner';
 	import { formatDateStringShortDay } from '$lib/utils/date';
 	import { getPaymentMethodLabel } from '$lib/utils/payment';
+	import { untrack } from 'svelte';
 
 	interface Props {
 		bill: PaymentInformation;
@@ -50,13 +51,11 @@
 	};
 
 	$effect(() => {
-		if (!$form.id || $form.id.length) {
-			$form.id = $currentVisit.id;
-		}
-	});
-	$effect(() => {
-		if ($currentVisit.id && $currentVisit.id.length) {
-			$form.id = $currentVisit.id;
+		const visitId = $currentVisit.id;
+		if (visitId && visitId.length) {
+			untrack(() => {
+				$form.id = visitId;
+			});
 		}
 	});
 	let rest = $derived(Math.max(currency(bill.total).subtract(bill.total_paid).value, 0));

--- a/src/lib/schemas/visit.ts
+++ b/src/lib/schemas/visit.ts
@@ -14,7 +14,7 @@ export const updateVisitSchema = addVisitSchema.extend({
 		.default(0)
 		.or(z.string().regex(/\d+/).transform(Number))
 		.default(0),
-	doctor: z.string().min(1, { message: 'Veuillez choisir un médecin' }).optional()
+	doctor: z.string().optional().default('')
 });
 
 export const payVisitSchema = z.object({

--- a/src/lib/services/funds.ts
+++ b/src/lib/services/funds.ts
@@ -193,11 +193,13 @@ export class FundsService {
 					};
 				}
 
-				const user = (transaction.expand as RecordModel).user as unknown as UsersResponse;
+				const user = (transaction.expand as RecordModel).user as unknown as
+					| UsersResponse
+					| undefined;
 
 				return {
 					...transaction,
-					user: user.name,
+					user: user?.name,
 					category: transaction.amount > 0 ? 'revenu' : 'frais'
 				} as Fund;
 			})
@@ -227,10 +229,12 @@ export class FundsService {
 		const balance = currency(income).subtract(expense).value;
 
 		const unpaidBills = await this.pb.collection('bills').getFullList<BillsResponse>({
-			filter: this.pb.filter('total_paid < total && created >= {:start} && created <= {:end}', {
-				start: new Date(startDate),
-				end: new Date(endDate)
-			})
+			filter: startDate.startsWith('@')
+				? `total_paid < total && created >= ${startDate} && created <= ${endDate}`
+				: this.pb.filter('total_paid < total && created >= {:start} && created <= {:end}', {
+						start: new Date(startDate),
+						end: new Date(endDate)
+					})
 		});
 
 		const remaining = unpaidBills.reduce(

--- a/src/routes/(app)/agenda/+page.svelte
+++ b/src/routes/(app)/agenda/+page.svelte
@@ -24,6 +24,9 @@
 	let { data }: Props = $props();
 	let { events, addForm, updateForm } = $derived(data);
 
+	addEventFormStore.set(addForm);
+	updateEventFormStore.set(updateForm);
+
 	$effect(() => {
 		addEventFormStore.set(addForm);
 	});

--- a/src/routes/(app)/animals/+page.svelte
+++ b/src/routes/(app)/animals/+page.svelte
@@ -10,6 +10,11 @@
 	let { data }: Props = $props();
 
 	let { pageInfo, removeForm, updateForm } = $derived(data);
+
+	deleteAnimalFormStore.set(removeForm);
+	updateAnimalFormStore.set(updateForm);
+	animalsPageInfo.set(pageInfo);
+
 	$effect(() => {
 		deleteAnimalFormStore.set(removeForm);
 	});

--- a/src/routes/(app)/animals/[id]/+page.svelte
+++ b/src/routes/(app)/animals/[id]/+page.svelte
@@ -41,6 +41,13 @@
 		...(animal.deceased ? [{ name: 'Décédé le', value: formatDateString(animal.deathdate) }] : [])
 	] satisfies entityDetailsList);
 
+	updateAnimalFormStore.set(data.form);
+	addVisitFormStore.set(data.addForm);
+	updateVisitFormStore.set(data.updateForm);
+	visitItems.set(visits);
+	currentAnimal.set({ ...animal, client: animal.client.name });
+	vaccinationVisitList.set(vaccinationVisits);
+
 	$effect(() => {
 		updateAnimalFormStore.set(data.form);
 	});

--- a/src/routes/(app)/clients/+page.svelte
+++ b/src/routes/(app)/clients/+page.svelte
@@ -15,6 +15,12 @@
 	let { data }: Props = $props();
 
 	let { shortCut, pageInfo, addForm, updateForm, deleteForm } = $derived(data);
+
+	clientsPageInfo.set(pageInfo);
+	addClientFormStore.set(addForm);
+	updateClientFormStore.set(updateForm);
+	removeClientFormStore.set(deleteForm);
+
 	$effect(() => {
 		clientsPageInfo.set(pageInfo);
 	});

--- a/src/routes/(app)/clients/[id]/+page.svelte
+++ b/src/routes/(app)/clients/[id]/+page.svelte
@@ -35,6 +35,14 @@
 		{ name: 'Note', value: client.note ?? '-' }
 	]);
 
+	addAnimalFormStore.set(addForm);
+	updateAnimalFormStore.set(updateForm);
+	deleteAnimalFormStore.set(removeForm);
+	animals.set(client.animals);
+	updateClientFormStore.set(form);
+	clientBills.set(bills);
+	currentClient.set(client);
+
 	$effect(() => {
 		addAnimalFormStore.set(addForm);
 	});

--- a/src/routes/(app)/funds/+page.svelte
+++ b/src/routes/(app)/funds/+page.svelte
@@ -14,6 +14,10 @@
 
 	let { labels, balanceData, stats, pageInfo, addExpenses, addFundsForm } = $derived(data);
 
+	addFundsFormStore.set(addFundsForm);
+	addExpenseFormStore.set(addExpenses);
+	fundsPageInfo.set(pageInfo);
+
 	$effect(() => {
 		addFundsFormStore.set(addFundsForm);
 	});

--- a/src/routes/(app)/hospit/+page.svelte
+++ b/src/routes/(app)/hospit/+page.svelte
@@ -10,6 +10,9 @@
 	let { data }: Props = $props();
 
 	let { pageInfo } = $derived(data);
+
+	hospitPageInfo.set(pageInfo);
+
 	$effect(() => {
 		hospitPageInfo.set(pageInfo);
 	});

--- a/src/routes/(app)/hospit/view/+page.svelte
+++ b/src/routes/(app)/hospit/view/+page.svelte
@@ -14,6 +14,11 @@
 	let { data }: Props = $props();
 
 	let { cageList, changeHospitColorForm, updateHospitCompeltedStateForm } = $derived(data);
+
+	cagesInfo.set(cageList);
+	hospitChangeColorFormStore.set(changeHospitColorForm);
+	hospitUpdateCompletedStateFormStore.set(updateHospitCompeltedStateForm);
+
 	$effect(() => {
 		cagesInfo.set(cageList);
 	});

--- a/src/routes/(app)/queue/+page.svelte
+++ b/src/routes/(app)/queue/+page.svelte
@@ -11,6 +11,9 @@
 
 	let { data }: Props = $props();
 
+	updateQueueFormStore.set(data.form);
+	queue.set(data.queue);
+
 	$effect(() => {
 		updateQueueFormStore.set(data.form);
 	});

--- a/src/routes/(app)/search/+page.svelte
+++ b/src/routes/(app)/search/+page.svelte
@@ -9,6 +9,8 @@
 
 	let { data }: Props = $props();
 
+	searchPage.set(data);
+
 	$effect(() => {
 		searchPage.set(data);
 	});

--- a/src/routes/(app)/stats/+page.svelte
+++ b/src/routes/(app)/stats/+page.svelte
@@ -11,6 +11,9 @@
 	let { data }: Props = $props();
 
 	let { page } = $derived(data);
+
+	inventorySalesPageInfo.set(page);
+
 	$effect(() => {
 		inventorySalesPageInfo.set(page);
 	});

--- a/src/routes/(app)/store/+page.svelte
+++ b/src/routes/(app)/store/+page.svelte
@@ -29,6 +29,10 @@
 		totalSoldItems
 	} = $derived(data);
 
+	inventoryItems.set(
+		items.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
+	);
+
 	$effect(() => {
 		inventoryItems.set(
 			items.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
@@ -36,6 +40,11 @@
 	});
 
 	let { addForm, updateForm, sellForm, deleteForm } = $derived(data);
+
+	addInventoryFormStore.set(addForm);
+	updateInventoryFormStore.set(updateForm);
+	sellInventoryFormStore.set(sellForm);
+	removeInventoryFormStore.set(deleteForm);
 
 	let stats = $derived([
 		$inventoryItems.filter((item) => item.quantity === 0).length,

--- a/src/routes/(app)/visit/+page.svelte
+++ b/src/routes/(app)/visit/+page.svelte
@@ -9,6 +9,8 @@
 
 	let { data }: Props = $props();
 
+	activityPage.set(data);
+
 	$effect(() => {
 		activityPage.set(data);
 	});

--- a/src/routes/(app)/visit/[id]/+page.svelte
+++ b/src/routes/(app)/visit/[id]/+page.svelte
@@ -77,6 +77,35 @@
 		updateHospitCompeltedStateForm
 	} = $derived(data);
 
+	currentVisit.set(visit);
+	updateVisitFormStore.set(form);
+	addVisitToilettageFormStore.set(addToilettageForm);
+	removeVisitItemFormStore.set(removeToilettageForm);
+	medicalActsStore.set(medicalActs);
+	toilettageActs.set(toilettage);
+	surgicalActsStore.set(surgicalActs);
+	payVisitFormStore.set(payVisitForm);
+	addVisitFileFormStore.set(addFileForm);
+	removeVisitFileFormStore.set(removeFileForm);
+	updateVisitDiagnosticFormStore.set(updateDiagnosticForm);
+	updateVisitActionsFormStore.set(updateActionsForm);
+	addVisitStoreItemFormStore.set(addVisitStoreItemForm);
+	removeVisitStoreItemFormStore.set(removeVisitStoreItemForm);
+	addVisitMedicalActsFormStore.set(addMedicalActsForm);
+	removeVisitMedicalActFormStore.set(removeMedicalActForm);
+	addVisitSurgicalActsFormStore.set(addSurgicalActsForm);
+	removeVisitSurgicalActFormStore.set(removeSurgicalActForm);
+	updateVisitHospitalisationFormStore.set(updateVisitHospitForm);
+	cagesList.set(cages);
+	inventoryItems.set(storeItems);
+	if (generatedBill) visitBill.set(generatedBill);
+	removeVisitHospitalisationFormStore.set(removeVisitHospitForm);
+	updateVisitTreatmentFormStore.set(updateVisitTreatmentForm);
+	activeVisitTab.set(tab as VisitTabsType);
+	updateVisitItemFormStore.set(updateVisitItemForm);
+	doctorList.set(doctors);
+	hospitUpdateCompletedStateFormStore.set(updateHospitCompeltedStateForm);
+
 	$effect(() => {
 		currentVisit.set(visit);
 	});


### PR DESCRIPTION
## Summary

- Every page with store-dependent components was crashing with 500 during SSR because `$effect()` doesn't run server-side in Svelte 5, leaving stores undefined when child components read from them
- Fixed by adding synchronous store initialization in all 15 page components so stores are populated before child components render during SSR
- Fixed infinite `effect_update_depth_exceeded` loops in `updateAnimalForm`, `PaymentTab`, and `InfoTab` caused by effects that read and write the same `$form` store, using `untrack()` to break the cycles
- Fixed silent visit update failures caused by the `doctor` schema field rejecting empty strings (`min(1).optional()` allows undefined but not `""`)
- Fixed `funds.ts` crashing on PocketBase `@todayStart` date macros in `transactionsTotals` and on transactions with deleted users