### PR TITLE
Fix remaining Svelte 5 effect loops and checkbox bindings

### DIFF
--- a/src/lib/components/forms/agenda/UpdateEventForm.svelte
+++ b/src/lib/components/forms/agenda/UpdateEventForm.svelte
@@ -10,6 +10,7 @@
 	import type { AgendaResponse } from '$types';
 	import { toast } from 'svelte-sonner';
 	import DoubleArrow from '$components/icons/DoubleArrow.svelte';
+	import { untrack } from 'svelte';
 	import CalendarIcon from '$components/icons/CalendarIcon.svelte';
 	import { getMaxSelectionDate } from '$lib/utils/date';
 
@@ -39,12 +40,16 @@
 	});
 
 	$effect(() => {
-		$form.id = item.id;
-		$form.title = item.title;
-		$form.description = item.description;
-		$form.location = item.location;
-		$form.start = formatISO(start);
-		$form.end = formatISO(end);
+		const s = start;
+		const e = end;
+		untrack(() => {
+			$form.id = item.id;
+			$form.title = item.title;
+			$form.description = item.description;
+			$form.location = item.location;
+			$form.start = formatISO(s);
+			$form.end = formatISO(e);
+		});
 	});
 
 	$effect(() => {

--- a/src/lib/components/forms/clients/UpdateClientForm.svelte
+++ b/src/lib/components/forms/clients/UpdateClientForm.svelte
@@ -6,6 +6,7 @@
 	import SubmitButton from '$components/buttons/SubmitButton.svelte';
 	import TextAreaField from '$components/inputs/TextAreaField.svelte';
 	import Edit from '$components/icons/Edit.svelte';
+	import { untrack } from 'svelte';
 
 	interface Props {
 		open?: boolean;
@@ -26,25 +27,16 @@
 	});
 
 	$effect(() => {
-		$form.id = $currentClient.id;
-	});
-	$effect(() => {
-		$form.firstname = $currentClient.firstname;
-	});
-	$effect(() => {
-		$form.lastname = $currentClient.lastname;
-	});
-	$effect(() => {
-		$form.address = $currentClient.address;
-	});
-	$effect(() => {
-		$form.tel = $currentClient.tel;
-	});
-	$effect(() => {
-		$form.email = $currentClient.email;
-	});
-	$effect(() => {
-		$form.note = $currentClient.note;
+		const client = $currentClient;
+		untrack(() => {
+			$form.id = client.id;
+			$form.firstname = client.firstname;
+			$form.lastname = client.lastname;
+			$form.address = client.address;
+			$form.tel = client.tel;
+			$form.email = client.email;
+			$form.note = client.note;
+		});
 	});
 
 	$effect(() => {

--- a/src/lib/components/forms/inventory/UpdateInventoryItemForm.svelte
+++ b/src/lib/components/forms/inventory/UpdateInventoryItemForm.svelte
@@ -9,6 +9,7 @@
 	import { updatedInventoryItem, updateInventoryFormStore } from '$lib/store/inventory';
 	import { toast } from 'svelte-sonner';
 	import InventoryCube from '$components/icons/InventoryCube.svelte';
+	import { untrack } from 'svelte';
 
 	interface Props {
 		open?: boolean;
@@ -29,16 +30,18 @@
 
 	$effect(() => {
 		const value = $updatedInventoryItem;
-		$form.alert = value.alert;
-		$form.code = value.code;
-		$form.cost = value.cost;
-		$form.id = value.id;
-		$form.name = value.name;
-		$form.price = value.price;
-		$form.quantity = value.quantity;
-		$form.tva = value.tva;
-		$form.description = value.description;
-		$form.gain = value.gain;
+		untrack(() => {
+			$form.alert = value.alert;
+			$form.code = value.code;
+			$form.cost = value.cost;
+			$form.id = value.id;
+			$form.name = value.name;
+			$form.price = value.price;
+			$form.quantity = value.quantity;
+			$form.tva = value.tva;
+			$form.description = value.description;
+			$form.gain = value.gain;
+		});
 	});
 
 	let htcost = $derived(

--- a/src/lib/components/forms/visit/AddVisitForm.svelte
+++ b/src/lib/components/forms/visit/AddVisitForm.svelte
@@ -62,7 +62,6 @@
 				type="checkbox"
 				id="control"
 				name="control"
-				value={$form.control}
 				class="hidden peer"
 			/>
 			<label
@@ -81,7 +80,6 @@
 				type="checkbox"
 				id="vaccination"
 				name="vaccination"
-				value={$form.vaccination}
 				class="hidden peer"
 			/>
 			<label

--- a/src/lib/components/tabs/visit/ActionsTab.svelte
+++ b/src/lib/components/tabs/visit/ActionsTab.svelte
@@ -6,6 +6,7 @@
 	import { formatDateString } from '$utils/date';
 	import { defaultEditorOptions } from '$utils/editor';
 	import { toast } from 'svelte-sonner';
+	import { untrack } from 'svelte';
 
 	const { form, enhance, submitting, allErrors } = superForm($updateVisitActionsFormStore, {
 		id: 'update-actions',
@@ -20,10 +21,11 @@
 	});
 
 	$effect(() => {
-		$form.id = $currentVisit.id;
-	});
-	$effect(() => {
-		$form.actions = $currentVisit.actions;
+		const visit = $currentVisit;
+		untrack(() => {
+			$form.id = visit.id;
+			$form.actions = visit.actions;
+		});
 	});
 
 	$effect(() => {

--- a/src/lib/components/tabs/visit/DiagnosticsTab.svelte
+++ b/src/lib/components/tabs/visit/DiagnosticsTab.svelte
@@ -6,6 +6,7 @@
 	import { formatDateString } from '$utils/date';
 	import { defaultEditorOptions } from '$utils/editor';
 	import { toast } from 'svelte-sonner';
+	import { untrack } from 'svelte';
 
 	const { form, enhance, submitting, allErrors } = superForm($updateVisitDiagnosticFormStore, {
 		id: 'update-diagnostic',
@@ -20,10 +21,11 @@
 	});
 
 	$effect(() => {
-		$form.id = $currentVisit.id;
-	});
-	$effect(() => {
-		$form.observations = $currentVisit.observations;
+		const visit = $currentVisit;
+		untrack(() => {
+			$form.id = visit.id;
+			$form.observations = visit.observations;
+		});
 	});
 
 	$effect(() => {

--- a/src/lib/components/tabs/visit/HospitTab.svelte
+++ b/src/lib/components/tabs/visit/HospitTab.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import Select from 'svelte-select';
 	import fr from 'date-fns/locale/fr/index';
 	import { superForm } from 'sveltekit-superforms';
@@ -125,24 +126,15 @@
 
 	let disabled = $derived(!$form.cage || !$form.start || !$form.end);
 	$effect(() => {
-		$form.id = $currentVisit.id;
-	});
-	$effect(() => {
-		$form.start = $currentVisit.hospit.start?.length
-			? new Date($currentVisit.hospit.start)
-			: new Date();
-	});
-	$effect(() => {
-		$form.end = $currentVisit.hospit.end?.length ? new Date($currentVisit.hospit.end) : new Date();
-	});
-	$effect(() => {
-		$form.cage = $currentVisit.hospit.cage;
-	});
-	$effect(() => {
-		$form.note = $currentVisit.hospit.note;
-	});
-	$effect(() => {
-		$form.price = $currentVisit.hospit.price;
+		const visit = $currentVisit;
+		untrack(() => {
+			$form.id = visit.id;
+			$form.start = visit.hospit.start?.length ? new Date(visit.hospit.start) : new Date();
+			$form.end = visit.hospit.end?.length ? new Date(visit.hospit.end) : new Date();
+			$form.cage = visit.hospit.cage;
+			$form.note = visit.hospit.note;
+			$form.price = visit.hospit.price;
+		});
 	});
 	let cages = $derived(
 		$cagesList.map((cage) => ({

--- a/src/lib/components/tabs/visit/TreatmentTab.svelte
+++ b/src/lib/components/tabs/visit/TreatmentTab.svelte
@@ -6,6 +6,7 @@
 	import { formatDateString } from '$utils/date';
 	import { defaultEditorOptions } from '$utils/editor';
 	import { toast } from 'svelte-sonner';
+	import { untrack } from 'svelte';
 
 	const { form, enhance, submitting, allErrors } = superForm($updateVisitTreatmentFormStore, {
 		id: 'update-treatment',
@@ -20,10 +21,11 @@
 	});
 
 	$effect(() => {
-		$form.id = $currentVisit.id;
-	});
-	$effect(() => {
-		$form.treatment = $currentVisit.treatment;
+		const visit = $currentVisit;
+		untrack(() => {
+			$form.id = visit.id;
+			$form.treatment = visit.treatment;
+		});
 	});
 
 	$effect(() => {


### PR DESCRIPTION
## Summary

- Multiple form components had separate `$effect()` calls that each wrote to `$form`, causing `effect_update_depth_exceeded` infinite loops in Svelte 5 when opening edit modals or visit tabs
- Consolidated these into single effects with `untrack()` so form initialization runs once without triggering cascading re-evaluations
- Affected components: UpdateClientForm, UpdateInventoryItemForm, UpdateEventForm, and visit tabs (ActionsTab, DiagnosticsTab, TreatmentTab, HospitTab)
- Removed invalid `value={$form.control}` and `value={$form.vaccination}` on checkbox inputs in AddVisitForm that conflict with `bind:checked` in Svelte 5