### PR TITLE
fix: visit printables breaking page layout

### DIFF
--- a/src/lib/components/display/VisitPrintables.svelte
+++ b/src/lib/components/display/VisitPrintables.svelte
@@ -94,7 +94,7 @@
 	{/if}
 </div>
 
-<div class="screen:hidden px-0 w-full print-content">
+<div class="hidden print:block px-0 w-full print-content">
 	<PrintPdf bind:print>
 		<Page>
 			{#if showBill}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -48,7 +48,7 @@
 
 <Nav />
 <div
-	class="min-h-screen w-full bg-white dark:bg-gray-900 overflow-hidden gradiant flex flex-col pt-10 xl:pt-16"
+	class="min-h-screen w-full bg-white dark:bg-gray-900 overflow-hidden gradiant flex flex-col pt-10 xl:pt-16 print:min-h-0 print:pt-0"
 >
 	{#if $globalLoading}
 		<LoadingSpinner />

--- a/src/routes/(app)/visit/[id]/+page.svelte
+++ b/src/routes/(app)/visit/[id]/+page.svelte
@@ -195,9 +195,11 @@
 	);
 </script>
 
-<div class="flex flex-col lg:flex-row lg:pl-5 w-full lg:overflow-x-auto">
+<div class="flex flex-col lg:flex-row lg:pl-5 w-full lg:overflow-x-auto print:pl-0">
 	<TabContainer />
-	<div class="w-full flex flex-col lg:pl-5 lg:pr-3 gap-3 lg:pt-10 pb-10 lg:min-w-[425px]">
+	<div
+		class="w-full flex flex-col lg:pl-5 lg:pr-3 gap-3 lg:pt-10 pb-10 lg:min-w-[425px] print:p-0 print:gap-0"
+	>
 		<div class="flex flex-col gap-2 lg:gap-5 w-full">
 			<VisitPrintables
 				report={visit.observations}


### PR DESCRIPTION
## Summary

- `screen:hidden` is not a valid Tailwind v4 variant, so the print content (bill, prescription, report, certificate) was rendering directly in the visit page instead of being hidden until print
- Layout containers kept their `min-h-screen` and padding during print, pushing actual content to page 2 and leaving an empty first page