### PR TITLE
fix: search page crash on animals without clients

### DIFF
--- a/src/lib/components/display/search/SearchList.svelte
+++ b/src/lib/components/display/search/SearchList.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { browser } from '$app/environment';
-	import { goto } from '$app/navigation';
 	import SearchAnimalList from '$components/lists/search/SearchAnimalList.svelte';
 	import SearchClientList from '$components/lists/search/SearchClientList.svelte';
 	import { searchPage } from '$lib/store/search';
@@ -8,30 +6,13 @@
 	import EmptyTable from '$components/display/EmptyTable.svelte';
 	import BackArrow from '$components/icons/BackArrow.svelte';
 	import ForwardArrow from '$components/icons/ForwardArrow.svelte';
+	import { nextPage as goNextPage, previousPage as goPreviousPage } from '$utils/pagination';
 
-	const animals = $searchPage.items as AnimalsResponse[];
-	const clients = $searchPage.items as ClientsResponse[];
+	let animals = $derived($searchPage.items as AnimalsResponse[]);
+	let clients = $derived($searchPage.items as ClientsResponse[]);
 
-	let currentUrl = $derived(browser ? document.location.href : '');
-
-	const nextPage = () => {
-		if ($searchPage.page === $searchPage.totalPages) return;
-
-		const nextUrl = new URL(currentUrl);
-
-		nextUrl.searchParams.set('page', `${$searchPage.page + 1}`);
-
-		goto(nextUrl);
-	};
-
-	const previousPage = () => {
-		if ($searchPage.page === 1) return;
-
-		const prevUrl = new URL(currentUrl);
-
-		prevUrl.searchParams.set('page', `${$searchPage.page - 1}`);
-		goto(prevUrl);
-	};
+	const nextPage = () => goNextPage($searchPage.page, $searchPage.totalPages);
+	const previousPage = () => goPreviousPage($searchPage.page);
 
 	let { page } = $derived($searchPage);
 </script>

--- a/src/routes/(app)/search/+page.server.ts
+++ b/src/routes/(app)/search/+page.server.ts
@@ -1,6 +1,7 @@
 import type { AnimalsResponse, ClientsResponse, SearchEntityType } from '$types';
 import type { RecordModel } from 'pocketbase';
 import type { PageServerLoad } from './$types';
+import { unknownClient } from '$lib/utils/client';
 
 export const load = (async ({ locals: { pb }, url: { searchParams } }) => {
 	const page = parseInt(searchParams.get('page') ?? '1');
@@ -28,10 +29,21 @@ export const load = (async ({ locals: { pb }, url: { searchParams } }) => {
 	let items = results.items;
 
 	if (target === 'animal') {
-		items = items.map((animal) => ({
-			...animal,
-			client: ((animal.expand as RecordModel).client as ClientsResponse).name || ''
-		}));
+		items = items.map((animal) => {
+			const expansion = animal.expand as RecordModel;
+			let name = unknownClient.name;
+
+			if (expansion?.client) {
+				name = (expansion.client as ClientsResponse).name;
+			} else {
+				console.error('anomaly: client not found');
+			}
+
+			return {
+				...animal,
+				client: name
+			};
+		});
 	}
 
 	return {


### PR DESCRIPTION
## Summary

- The global search page (`/search`) crashed with a TypeError when searching for animals that have no client, because the client expand was accessed without a null check. This caused the OOM errors seen in production as the server repeatedly failed and retried.
- Search result items in `SearchList.svelte` were captured as non-reactive `const` values, so the list never updated on pagination or new searches without a full page reload.
- Pagination in the search results built URLs from a stale `document.location.href` instead of using the shared pagination utility, causing incorrect navigation state.