### PR TITLE
fix: migrate deprecated tailwind v3 utilities to v4 syntax

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -4,6 +4,17 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* Restore Tailwind v3 default border color (v4 defaults to currentColor) */
+@layer base {
+	*,
+	::after,
+	::before,
+	::backdrop,
+	::file-selector-button {
+		border-color: var(--color-gray-200, currentColor);
+	}
+}
+
 @theme {
 	--color-blueGray-50: rgba(248, 250, 252, 1);
 	--color-blueGray-100: rgba(241, 245, 249, 1);

--- a/src/lib/components/ConfirmationDialog.svelte
+++ b/src/lib/components/ConfirmationDialog.svelte
@@ -16,9 +16,7 @@
 	role="dialog"
 	aria-modal="true"
 >
-	<div
-		class="fixed inset-0 bg-gray-500 dark:bg-gray-900 bg-opacity-75 dark:bg-opacity-80 transition-opacity"
-	></div>
+	<div class="fixed inset-0 bg-gray-500/75 dark:bg-gray-900/80 transition-opacity"></div>
 
 	<div class="fixed inset-0 z-50 w-screen overflow-y-auto">
 		<div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -15,9 +15,7 @@
 		role="dialog"
 		aria-modal="true"
 	>
-		<div
-			class="fixed inset-0 bg-gray-500 dark:bg-gray-900 bg-opacity-75 dark:bg-opacity-80 transition-opacity"
-		></div>
+		<div class="fixed inset-0 bg-gray-500/75 dark:bg-gray-900/80 transition-opacity"></div>
 		<div
 			class="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0 w-full"
 		>

--- a/src/lib/components/buttons/PrimaryButton.svelte
+++ b/src/lib/components/buttons/PrimaryButton.svelte
@@ -29,12 +29,8 @@
 		: 'bg-emerald-600'} rounded-md sm:mt-0 sm:w-1/2 sm:mx-2 {disable
 		? 'hover:bg-slate-500'
 		: 'hover:bg-emerald-500'} focus:outline-none focus:ring {disable
-		? 'focus:ring-slate-300'
-		: 'focus:ring-emerald-300'} focus:ring-opacity-40 {full
-		? 'lg:w-full lg:mx-0'
-		: small
-			? 'lg:max-w-xs'
-			: ''}"
+		? 'focus:ring-slate-300/40'
+		: 'focus:ring-emerald-300/40'} {full ? 'lg:w-full lg:mx-0' : small ? 'lg:max-w-xs' : ''}"
 >
 	{#if loading}
 		<svg

--- a/src/lib/components/buttons/SecondaryButton.svelte
+++ b/src/lib/components/buttons/SecondaryButton.svelte
@@ -29,12 +29,8 @@
 		: 'bg-blue-500'} rounded-md sm:mt-0 sm:w-1/2 sm:mx-5 {disable
 		? 'hover:bg-slate-500'
 		: 'hover:bg-blue-400'} focus:outline-none focus:ring {disable
-		? 'focus:ring-slate-300'
-		: 'focus:ring-blue-300'} focus:ring-opacity-40 {full
-		? 'lg:w-full lg:mx-0'
-		: small
-			? 'lg:max-w-xs'
-			: ''}"
+		? 'focus:ring-slate-300/40'
+		: 'focus:ring-blue-300/40'} {full ? 'lg:w-full lg:mx-0' : small ? 'lg:max-w-xs' : ''}"
 >
 	{#if loading}
 		<svg

--- a/src/lib/components/buttons/SubmitButton.svelte
+++ b/src/lib/components/buttons/SubmitButton.svelte
@@ -26,12 +26,8 @@
 		: 'bg-emerald-600'} rounded-md sm:mt-0 sm:w-1/2 sm:mx-2 {disable
 		? 'hover:bg-slate-500'
 		: 'hover:bg-emerald-500'} focus:outline-none focus:ring {disable
-		? 'focus:ring-slate-300'
-		: 'focus:ring-emerald-300'} focus:ring-opacity-40 {full
-		? 'lg:w-full lg:mx-0'
-		: small
-			? 'lg:max-w-xs'
-			: ''}"
+		? 'focus:ring-slate-300/40'
+		: 'focus:ring-emerald-300/40'} {full ? 'lg:w-full lg:mx-0' : small ? 'lg:max-w-xs' : ''}"
 >
 	{#if loading}
 		<svg

--- a/src/lib/components/buttons/removeButton.svelte
+++ b/src/lib/components/buttons/removeButton.svelte
@@ -29,12 +29,8 @@
 		: 'bg-red-500'} rounded-md sm:mt-0 sm:w-1/2 sm:mx-2 {disable
 		? 'hover:bg-slate-500'
 		: 'hover:bg-red-400'} focus:outline-none focus:ring {disable
-		? 'focus:ring-slate-300'
-		: 'focus:ring-red-300'} focus:ring-opacity-40 {full
-		? 'lg:w-full lg:mx-0'
-		: small
-			? 'lg:max-w-xs'
-			: ''}"
+		? 'focus:ring-slate-300/40'
+		: 'focus:ring-red-300/40'} {full ? 'lg:w-full lg:mx-0' : small ? 'lg:max-w-xs' : ''}"
 >
 	{#if loading}
 		<svg

--- a/src/lib/components/forms/SelectActForm.svelte
+++ b/src/lib/components/forms/SelectActForm.svelte
@@ -69,7 +69,7 @@
 			<button
 				type="button"
 				onclick={() => (open = false)}
-				class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300 focus:ring-opacity-40"
+				class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300/40"
 			>
 				Annuler
 			</button>
@@ -77,7 +77,7 @@
 			<button
 				onclick={handleConfirm}
 				type="button"
-				class="w-full px-4 py-2 mt-3 text-sm font-medium tracking-wide text-white capitalize transition-colors duration-300 transform bg-blue-600 rounded-md sm:mt-0 sm:w-1/2 sm:mx-2 hover:bg-blue-500 focus:outline-none focus:ring focus:ring-blue-300 focus:ring-opacity-40"
+				class="w-full px-4 py-2 mt-3 text-sm font-medium tracking-wide text-white capitalize transition-colors duration-300 transform bg-blue-600 rounded-md sm:mt-0 sm:w-1/2 sm:mx-2 hover:bg-blue-500 focus:outline-none focus:ring focus:ring-blue-300/40"
 			>
 				Confirmer
 			</button>

--- a/src/lib/components/forms/agenda/AddEventForm.svelte
+++ b/src/lib/components/forms/agenda/AddEventForm.svelte
@@ -104,14 +104,14 @@
 		<button
 			type="button"
 			onclick={() => (open = false)}
-			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300 focus:ring-opacity-40"
+			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300/40"
 		>
 			Annuler
 		</button>
 
 		<button
 			type="submit"
-			class="w-full px-4 py-2 mt-3 text-sm font-medium tracking-wide text-white capitalize transition-colors duration-300 transform bg-emerald-600 rounded-md sm:mt-0 sm:w-1/2 sm:mx-2 hover:bg-emerald-500 focus:outline-none focus:ring focus:ring-emerald-300 focus:ring-opacity-40"
+			class="w-full px-4 py-2 mt-3 text-sm font-medium tracking-wide text-white capitalize transition-colors duration-300 transform bg-emerald-600 rounded-md sm:mt-0 sm:w-1/2 sm:mx-2 hover:bg-emerald-500 focus:outline-none focus:ring focus:ring-emerald-300/40"
 		>
 			Confirmer
 		</button>

--- a/src/lib/components/forms/agenda/UpdateEventForm.svelte
+++ b/src/lib/components/forms/agenda/UpdateEventForm.svelte
@@ -116,14 +116,14 @@
 		<button
 			type="button"
 			onclick={() => (open = false)}
-			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300 focus:ring-opacity-40"
+			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300/40"
 		>
 			Annuler
 		</button>
 
 		<button
 			type="submit"
-			class="w-full px-4 py-2 mt-3 text-sm font-medium tracking-wide text-white capitalize transition-colors duration-300 transform bg-blue-600 rounded-md sm:mt-0 sm:w-1/2 sm:mx-2 hover:bg-blue-500 focus:outline-none focus:ring focus:ring-blue-300 focus:ring-opacity-40"
+			class="w-full px-4 py-2 mt-3 text-sm font-medium tracking-wide text-white capitalize transition-colors duration-300 transform bg-blue-600 rounded-md sm:mt-0 sm:w-1/2 sm:mx-2 hover:bg-blue-500 focus:outline-none focus:ring focus:ring-blue-300/40"
 		>
 			Confirmer
 		</button>

--- a/src/lib/components/forms/animals/AddAnimalForm.svelte
+++ b/src/lib/components/forms/animals/AddAnimalForm.svelte
@@ -119,7 +119,7 @@
 		<button
 			type="button"
 			onclick={() => (open = false)}
-			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300 focus:ring-opacity-40"
+			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300/40"
 		>
 			Annuler
 		</button>

--- a/src/lib/components/forms/animals/updateAnimalForm.svelte
+++ b/src/lib/components/forms/animals/updateAnimalForm.svelte
@@ -158,7 +158,7 @@
 		<button
 			type="button"
 			onclick={() => (open = false)}
-			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300 focus:ring-opacity-40"
+			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300/40"
 		>
 			Annuler
 		</button>

--- a/src/lib/components/forms/clients/AddClientForm.svelte
+++ b/src/lib/components/forms/clients/AddClientForm.svelte
@@ -74,7 +74,7 @@
 		<button
 			type="button"
 			onclick={() => (open = false)}
-			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300 focus:ring-opacity-40"
+			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300/40"
 		>
 			Annuler
 		</button>

--- a/src/lib/components/forms/clients/UpdateClientForm.svelte
+++ b/src/lib/components/forms/clients/UpdateClientForm.svelte
@@ -89,7 +89,7 @@
 		<button
 			type="button"
 			onclick={() => (open = false)}
-			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300 focus:ring-opacity-40"
+			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300/40"
 		>
 			Annuler
 		</button>

--- a/src/lib/components/forms/funds/AddExpenseForm.svelte
+++ b/src/lib/components/forms/funds/AddExpenseForm.svelte
@@ -119,7 +119,7 @@
 		<button
 			type="button"
 			onclick={() => (open = false)}
-			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300 focus:ring-opacity-40"
+			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300/40"
 		>
 			Annuler
 		</button>

--- a/src/lib/components/forms/funds/AddFundsForm.svelte
+++ b/src/lib/components/forms/funds/AddFundsForm.svelte
@@ -113,7 +113,7 @@
 		<button
 			type="button"
 			onclick={() => (open = false)}
-			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300 focus:ring-opacity-40"
+			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300/40"
 		>
 			Annuler
 		</button>

--- a/src/lib/components/forms/inventory/AddInventoryItemForm.svelte
+++ b/src/lib/components/forms/inventory/AddInventoryItemForm.svelte
@@ -149,7 +149,7 @@
 		<button
 			type="button"
 			onclick={() => (open = false)}
-			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300 focus:ring-opacity-40"
+			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300/40"
 		>
 			Annuler
 		</button>

--- a/src/lib/components/forms/inventory/SellInventoryItemForm.svelte
+++ b/src/lib/components/forms/inventory/SellInventoryItemForm.svelte
@@ -269,7 +269,7 @@
 		<button
 			type="button"
 			onclick={() => (open = false)}
-			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300 focus:ring-opacity-40"
+			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300/40"
 		>
 			Annuler
 		</button>

--- a/src/lib/components/forms/inventory/UpdateInventoryItemForm.svelte
+++ b/src/lib/components/forms/inventory/UpdateInventoryItemForm.svelte
@@ -165,7 +165,7 @@
 		<button
 			type="button"
 			onclick={() => (open = false)}
-			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300 focus:ring-opacity-40"
+			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300/40"
 		>
 			Annuler
 		</button>

--- a/src/lib/components/forms/visit/AddVisitForm.svelte
+++ b/src/lib/components/forms/visit/AddVisitForm.svelte
@@ -98,7 +98,7 @@
 		<button
 			type="button"
 			onclick={() => (open = false)}
-			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300 focus:ring-opacity-40"
+			class="w-full px-4 py-2 text-sm font-medium tracking-wide text-gray-700 capitalize transition-colors duration-300 transform border border-gray-200 rounded-md sm:w-1/2 sm:mx-2 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800 hover:bg-gray-100 focus:outline-none focus:ring focus:ring-gray-300/40"
 		>
 			Annuler
 		</button>

--- a/src/lib/components/lists/ActivityList.svelte
+++ b/src/lib/components/lists/ActivityList.svelte
@@ -133,7 +133,7 @@
 						bind:value={search}
 						placeholder="Rechercher par animal, client, téléphone et motif"
 						type="text"
-						class="block w-full py-1.5 text-gray-700 bg-white border border-gray-200 rounded-lg md:w-[500px] placeholder-gray-400/70 pl-3 focus:border-blue-400 focus:ring-blue-300 focus:outline-none focus:ring focus:ring-opacity-40"
+						class="block w-full py-1.5 text-gray-700 bg-white border border-gray-200 rounded-lg md:w-[500px] placeholder-gray-400/70 pl-3 focus:border-blue-400 focus:ring-blue-300/40 focus:outline-none focus:ring"
 					/>
 				</div>
 			</form>

--- a/src/lib/components/lists/AnimalList.svelte
+++ b/src/lib/components/lists/AnimalList.svelte
@@ -233,7 +233,7 @@
 							bind:value={search}
 							type="text"
 							placeholder="Rechercher par nom, espèce, race, identifiant..."
-							class="block w-full py-1.5 pr-5 text-gray-700 bg-white border border-gray-200 rounded-lg placeholder-gray-400/70 pl-11 rtl:pr-11 rtl:pl-5 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300 focus:outline-none focus:ring focus:ring-opacity-40"
+							class="block w-full py-1.5 pr-5 text-gray-700 bg-white border border-gray-200 rounded-lg placeholder-gray-400/70 pl-11 rtl:pr-11 rtl:pl-5 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-none focus:ring"
 						/>
 					</div>
 				</form>

--- a/src/lib/components/lists/ClientAnimalsList.svelte
+++ b/src/lib/components/lists/ClientAnimalsList.svelte
@@ -266,7 +266,7 @@
 						bind:value={search}
 						type="text"
 						placeholder="Rechercher"
-						class="block w-full py-1.5 pr-5 text-gray-700 bg-white border border-gray-200 rounded-lg placeholder-gray-400/70 pl-11 rtl:pr-11 rtl:pl-5 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300 focus:outline-none focus:ring focus:ring-opacity-40"
+						class="block w-full py-1.5 pr-5 text-gray-700 bg-white border border-gray-200 rounded-lg placeholder-gray-400/70 pl-11 rtl:pr-11 rtl:pl-5 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-none focus:ring"
 					/>
 				</div>
 			</div>

--- a/src/lib/components/lists/ClientList.svelte
+++ b/src/lib/components/lists/ClientList.svelte
@@ -160,7 +160,7 @@
 							bind:value={search}
 							type="text"
 							placeholder="Chercher par nom, email, téléphone..."
-							class="block w-full py-1.5 pr-5 text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg md:w-4/12 placeholder-gray-400/70 dark:placeholder-gray-500 pl-11 rtl:pr-11 rtl:pl-5 focus:border-blue-400 dark:focus:border-blue-500 focus:ring-blue-300 dark:focus:ring-blue-500 focus:outline-none focus:ring focus:ring-opacity-40"
+							class="block w-full py-1.5 pr-5 text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg md:w-4/12 placeholder-gray-400/70 dark:placeholder-gray-500 pl-11 rtl:pr-11 rtl:pl-5 focus:border-blue-400 dark:focus:border-blue-500 focus:ring-blue-300/40 dark:focus:ring-blue-500/40 focus:outline-none focus:ring"
 						/>
 					</div>
 				</form>

--- a/src/lib/components/lists/FundsList.svelte
+++ b/src/lib/components/lists/FundsList.svelte
@@ -220,7 +220,7 @@
 							bind:value={search}
 							type="text"
 							placeholder="Rechercher"
-							class="block w-full py-1.5 pr-2 text-gray-700 bg-white border border-gray-200 rounded-lg md:w-60 placeholder-gray-400/70 pl-5 rtl:pr-11 rtl:pl-5 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300 focus:outline-none focus:ring focus:ring-opacity-40"
+							class="block w-full py-1.5 pr-2 text-gray-700 bg-white border border-gray-200 rounded-lg md:w-60 placeholder-gray-400/70 pl-5 rtl:pr-11 rtl:pl-5 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-none focus:ring"
 						/>
 					</div>
 				</form>

--- a/src/lib/components/lists/HospitList.svelte
+++ b/src/lib/components/lists/HospitList.svelte
@@ -130,7 +130,7 @@
 						bind:value={search}
 						placeholder="Rechercher par cage, animal, client, téléphone, note"
 						type="text"
-						class="block w-full py-1.5 text-gray-700 bg-white border border-gray-200 rounded-lg md:w-[500px] placeholder-gray-400/70 pl-3 focus:border-blue-400 focus:ring-blue-300 focus:outline-none focus:ring focus:ring-opacity-40"
+						class="block w-full py-1.5 text-gray-700 bg-white border border-gray-200 rounded-lg md:w-[500px] placeholder-gray-400/70 pl-3 focus:border-blue-400 focus:ring-blue-300/40 focus:outline-none focus:ring"
 					/>
 				</div>
 			</form>

--- a/src/lib/components/lists/InventorySaleList.svelte
+++ b/src/lib/components/lists/InventorySaleList.svelte
@@ -167,7 +167,7 @@
 							bind:value={search}
 							type="text"
 							placeholder="Rechercher"
-							class="block w-full py-1.5 pr-2 text-gray-700 bg-white border border-gray-200 rounded-lg md:w-60 placeholder-gray-400/70 pl-5 rtl:pr-11 rtl:pl-5 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300 focus:outline-none focus:ring focus:ring-opacity-40"
+							class="block w-full py-1.5 pr-2 text-gray-700 bg-white border border-gray-200 rounded-lg md:w-60 placeholder-gray-400/70 pl-5 rtl:pr-11 rtl:pl-5 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-none focus:ring"
 						/>
 					</div>
 				</div>

--- a/src/lib/components/lists/QueueList.svelte
+++ b/src/lib/components/lists/QueueList.svelte
@@ -142,7 +142,7 @@
 						bind:value={search}
 						type="text"
 						placeholder="Rechercher"
-						class="block w-full py-1.5 pr-5 text-gray-700 bg-white border border-gray-200 rounded-lg md:w-60 placeholder-gray-400/70 pl-11 rtl:pr-11 rtl:pl-5 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300 focus:outline-none focus:ring focus:ring-opacity-40"
+						class="block w-full py-1.5 pr-5 text-gray-700 bg-white border border-gray-200 rounded-lg md:w-60 placeholder-gray-400/70 pl-11 rtl:pr-11 rtl:pl-5 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-none focus:ring"
 					/>
 				</div>
 			</div>

--- a/src/lib/components/lists/StoreList.svelte
+++ b/src/lib/components/lists/StoreList.svelte
@@ -266,7 +266,7 @@
 						bind:value={search}
 						type="text"
 						placeholder="Rechercher"
-						class="block w-full py-1.5 pr-5 text-gray-700 bg-white border border-gray-200 rounded-lg md:w-60 placeholder-gray-400/70 pl-11 rtl:pr-11 rtl:pl-5 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300 focus:outline-none focus:ring focus:ring-opacity-40"
+						class="block w-full py-1.5 pr-5 text-gray-700 bg-white border border-gray-200 rounded-lg md:w-60 placeholder-gray-400/70 pl-11 rtl:pr-11 rtl:pl-5 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-none focus:ring"
 					/>
 				</div>
 			</div>

--- a/src/lib/components/lists/VisitList.svelte
+++ b/src/lib/components/lists/VisitList.svelte
@@ -191,7 +191,7 @@
 					bind:value={search}
 					type="text"
 					placeholder="Rechercher"
-					class="block w-full py-1.5 pr-5 text-gray-700 bg-white border border-gray-200 rounded-lg md:w-60 placeholder-gray-400/70 pl-11 rtl:pr-11 rtl:pl-5 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300 focus:outline-none focus:ring focus:ring-opacity-40"
+					class="block w-full py-1.5 pr-5 text-gray-700 bg-white border border-gray-200 rounded-lg md:w-60 placeholder-gray-400/70 pl-11 rtl:pr-11 rtl:pl-5 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-none focus:ring"
 				/>
 			</div>
 		</div>

--- a/src/lib/components/lists/vaccinationList.svelte
+++ b/src/lib/components/lists/vaccinationList.svelte
@@ -49,7 +49,7 @@
 					bind:value={search}
 					type="text"
 					placeholder="Rechercher"
-					class="block w-full py-1.5 pr-5 text-gray-700 bg-white border border-gray-200 rounded-lg md:w-60 placeholder-gray-400/70 pl-11 rtl:pr-11 rtl:pl-5 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300 focus:outline-none focus:ring focus:ring-opacity-40"
+					class="block w-full py-1.5 pr-5 text-gray-700 bg-white border border-gray-200 rounded-lg md:w-60 placeholder-gray-400/70 pl-11 rtl:pr-11 rtl:pl-5 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-none focus:ring"
 				/>
 			</div>
 		</div>

--- a/src/routes/(login)/login/+page.svelte
+++ b/src/routes/(login)/login/+page.svelte
@@ -45,7 +45,7 @@
 			class="hidden bg-cover lg:block lg:w-2/3 transition-all duration-300 ease-in-out"
 			style="background-image: url(/bg-{imageNumber}.jpg)"
 		>
-			<div class="flex items-center h-full px-20 bg-gray-900 bg-opacity-40">
+			<div class="flex items-center h-full px-20 bg-gray-900/40">
 				<div>
 					<h2 class="text-3xl font-bold text-white sm:text-6xl uppercase">Vetixa</h2>
 
@@ -109,7 +109,7 @@
 								id="email"
 								bind:value={$form.email}
 								placeholder="example@example.com"
-								class="block w-full px-4 py-2 mt-2 text-gray-700 placeholder-gray-400 bg-white border border-gray-200 rounded-lg dark:placeholder-gray-600 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700 focus:border-blue-400 dark:focus:border-blue-400 focus:ring-blue-400 focus:outline-none focus:ring focus:ring-opacity-40"
+								class="block w-full px-4 py-2 mt-2 text-gray-700 placeholder-gray-400 bg-white border border-gray-200 rounded-lg dark:placeholder-gray-600 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700 focus:border-blue-400 dark:focus:border-blue-400 focus:ring-blue-400/40 focus:outline-none focus:ring"
 							/>
 						</div>
 
@@ -126,7 +126,7 @@
 								id="password"
 								bind:value={$form.password}
 								placeholder="*********"
-								class="block w-full px-4 py-2 mt-2 text-gray-700 placeholder-gray-400 bg-white border border-gray-200 rounded-lg dark:placeholder-gray-600 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700 focus:border-blue-400 dark:focus:border-blue-400 focus:ring-blue-400 focus:outline-none focus:ring focus:ring-opacity-40"
+								class="block w-full px-4 py-2 mt-2 text-gray-700 placeholder-gray-400 bg-white border border-gray-200 rounded-lg dark:placeholder-gray-600 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700 focus:border-blue-400 dark:focus:border-blue-400 focus:ring-blue-400/40 focus:outline-none focus:ring"
 							/>
 						</div>
 


### PR DESCRIPTION
## Summary

- Tailwind v4 changed the default border color from gray-200 to currentColor, causing black borders on age displays, filter tabs, table dividers, and other bordered elements across the app. Restored the v3 default via a base layer rule.
- Modal and dialog overlays were fully opaque because `bg-opacity-*` utilities were removed in v4. Replaced with v4 color modifier syntax (`bg-gray-500/75`).
- Focus rings on all inputs and buttons were rendering at full opacity because `ring-opacity-*` utilities are no longer supported. Merged opacity into the ring color class (`focus:ring-blue-300/40`).
- Fixed the login page overlay (`bg-gray-900/40`) which had the same opacity issue.