### PR TITLE
fix(site): sync package-lock.json with package.json

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -4672,6 +4672,21 @@
 				}
 			}
 		},
+		"node_modules/svelte-check/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/svelte-check/node_modules/readdirp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -4862,6 +4877,24 @@
 				"yaml": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/tailwindcss/node_modules/yaml": {
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/thenify": {


### PR DESCRIPTION
## Summary
- `npm ci` was failing in `site/` because `picomatch@4.0.4` and `yaml@2.8.3` were missing from the lockfile, blocking the Cloudflare Pages build
- Regenerated `site/package-lock.json` with `npm install --package-lock-only` so it matches `site/package.json`

## Test plan
- [x] `npm ci --dry-run` in `site/` no longer reports `EUSAGE` / missing packages