### PR TITLE
fix(site): type bind:this refs as possibly undefined

### DIFF
--- a/site/src/lib/components/Hero.svelte
+++ b/site/src/lib/components/Hero.svelte
@@ -4,17 +4,17 @@
 	import { isIntersecting } from '$lib/utils/observer';
 	import { onDestroy, onMount } from 'svelte';
 
-	let phoneRef: Element = $state();
+	let phoneRef: Element | undefined = $state();
 	let observer: IntersectionObserver | undefined;
 
 	onMount(() => {
 		observer = isIntersecting(isPhoneVisible);
 
-		observer?.observe(phoneRef);
+		if (phoneRef) observer?.observe(phoneRef);
 	});
 
 	onDestroy(() => {
-		observer?.unobserve(phoneRef);
+		if (phoneRef) observer?.unobserve(phoneRef);
 	});
 </script>
 

--- a/site/src/lib/components/landing/AgendaCard.svelte
+++ b/site/src/lib/components/landing/AgendaCard.svelte
@@ -3,8 +3,8 @@
 	import { isIntersecting } from '$lib/utils/observer';
 	import { onDestroy, onMount } from 'svelte';
 
-	let imageRef: Element = $state();
-	let textRef: Element = $state();
+	let imageRef: Element | undefined = $state();
+	let textRef: Element | undefined = $state();
 
 	let imageObserver: IntersectionObserver | undefined;
 	let textObserver: IntersectionObserver | undefined;
@@ -13,13 +13,13 @@
 		imageObserver = isIntersecting(agendaImageVisible);
 		textObserver = isIntersecting(agendaTextVisible);
 
-		imageObserver?.observe(imageRef);
-		textObserver?.observe(textRef);
+		if (imageRef) imageObserver?.observe(imageRef);
+		if (textRef) textObserver?.observe(textRef);
 	});
 
 	onDestroy(() => {
-		imageObserver?.unobserve(imageRef);
-		textObserver?.unobserve(textRef);
+		if (imageRef) imageObserver?.unobserve(imageRef);
+		if (textRef) textObserver?.unobserve(textRef);
 	});
 </script>
 

--- a/site/src/lib/components/landing/AnimalsClientsCard.svelte
+++ b/site/src/lib/components/landing/AnimalsClientsCard.svelte
@@ -3,8 +3,8 @@
 	import { isIntersecting } from '$lib/utils/observer';
 	import { onDestroy, onMount } from 'svelte';
 
-	let imageRef: Element = $state();
-	let textRef: Element = $state();
+	let imageRef: Element | undefined = $state();
+	let textRef: Element | undefined = $state();
 
 	let imageObserver: IntersectionObserver | undefined;
 	let textObserver: IntersectionObserver | undefined;
@@ -13,13 +13,13 @@
 		imageObserver = isIntersecting(animalsImageVisible);
 		textObserver = isIntersecting(animalsTextVisible);
 
-		imageObserver?.observe(imageRef);
-		textObserver?.observe(textRef);
+		if (imageRef) imageObserver?.observe(imageRef);
+		if (textRef) textObserver?.observe(textRef);
 	});
 
 	onDestroy(() => {
-		imageObserver?.unobserve(imageRef);
-		textObserver?.unobserve(textRef);
+		if (imageRef) imageObserver?.unobserve(imageRef);
+		if (textRef) textObserver?.unobserve(textRef);
 	});
 </script>
 

--- a/site/src/lib/components/landing/CaisseCard.svelte
+++ b/site/src/lib/components/landing/CaisseCard.svelte
@@ -3,8 +3,8 @@
 	import { isIntersecting } from '$lib/utils/observer';
 	import { onDestroy, onMount } from 'svelte';
 
-	let imageRef: Element = $state();
-	let textRef: Element = $state();
+	let imageRef: Element | undefined = $state();
+	let textRef: Element | undefined = $state();
 
 	let imageObserver: IntersectionObserver | undefined;
 	let textObserver: IntersectionObserver | undefined;
@@ -13,13 +13,13 @@
 		imageObserver = isIntersecting(caisseImageVisible);
 		textObserver = isIntersecting(caisseTextVisible);
 
-		imageObserver?.observe(imageRef);
-		textObserver?.observe(textRef);
+		if (imageRef) imageObserver?.observe(imageRef);
+		if (textRef) textObserver?.observe(textRef);
 	});
 
 	onDestroy(() => {
-		imageObserver?.unobserve(imageRef);
-		textObserver?.unobserve(textRef);
+		if (imageRef) imageObserver?.unobserve(imageRef);
+		if (textRef) textObserver?.unobserve(textRef);
 	});
 </script>
 

--- a/site/src/lib/components/landing/Contact.svelte
+++ b/site/src/lib/components/landing/Contact.svelte
@@ -3,8 +3,8 @@
 	import { isIntersecting } from '$lib/utils/observer';
 	import { onDestroy, onMount } from 'svelte';
 
-	let containerRef: Element = $state();
-	let textRef: Element = $state();
+	let containerRef: Element | undefined = $state();
+	let textRef: Element | undefined = $state();
 
 	let imageObserver: IntersectionObserver | undefined;
 	let textObserver: IntersectionObserver | undefined;
@@ -13,13 +13,13 @@
 		imageObserver = isIntersecting(contactContainerVisible);
 		textObserver = isIntersecting(contactTextVisible);
 
-		imageObserver?.observe(containerRef);
-		textObserver?.observe(textRef);
+		if (containerRef) imageObserver?.observe(containerRef);
+		if (textRef) textObserver?.observe(textRef);
 	});
 
 	onDestroy(() => {
-		imageObserver?.unobserve(containerRef);
-		textObserver?.unobserve(textRef);
+		if (containerRef) imageObserver?.unobserve(containerRef);
+		if (textRef) textObserver?.unobserve(textRef);
 	});
 </script>
 

--- a/site/src/lib/components/landing/HospitCard.svelte
+++ b/site/src/lib/components/landing/HospitCard.svelte
@@ -3,8 +3,8 @@
 	import { isIntersecting } from '$lib/utils/observer';
 	import { onDestroy, onMount } from 'svelte';
 
-	let imageRef: Element = $state();
-	let textRef: Element = $state();
+	let imageRef: Element | undefined = $state();
+	let textRef: Element | undefined = $state();
 
 	let imageObserver: IntersectionObserver | undefined;
 	let textObserver: IntersectionObserver | undefined;
@@ -13,13 +13,13 @@
 		imageObserver = isIntersecting(hospitImageVisible);
 		textObserver = isIntersecting(hospitTextVisible);
 
-		imageObserver?.observe(imageRef);
-		textObserver?.observe(textRef);
+		if (imageRef) imageObserver?.observe(imageRef);
+		if (textRef) textObserver?.observe(textRef);
 	});
 
 	onDestroy(() => {
-		imageObserver?.unobserve(imageRef);
-		textObserver?.unobserve(textRef);
+		if (imageRef) imageObserver?.unobserve(imageRef);
+		if (textRef) textObserver?.unobserve(textRef);
 	});
 </script>
 

--- a/site/src/lib/components/landing/StockCard.svelte
+++ b/site/src/lib/components/landing/StockCard.svelte
@@ -3,8 +3,8 @@
 	import { isIntersecting } from '$lib/utils/observer';
 	import { onDestroy, onMount } from 'svelte';
 
-	let imageRef: Element = $state();
-	let textRef: Element = $state();
+	let imageRef: Element | undefined = $state();
+	let textRef: Element | undefined = $state();
 
 	let imageObserver: IntersectionObserver | undefined;
 	let textObserver: IntersectionObserver | undefined;
@@ -13,13 +13,13 @@
 		imageObserver = isIntersecting(stockImageVisible);
 		textObserver = isIntersecting(stockTextVisible);
 
-		imageObserver?.observe(imageRef);
-		textObserver?.observe(textRef);
+		if (imageRef) imageObserver?.observe(imageRef);
+		if (textRef) textObserver?.observe(textRef);
 	});
 
 	onDestroy(() => {
-		imageObserver?.unobserve(imageRef);
-		textObserver?.unobserve(textRef);
+		if (imageRef) imageObserver?.unobserve(imageRef);
+		if (textRef) textObserver?.unobserve(textRef);
 	});
 </script>
 

--- a/site/src/lib/components/landing/VisitManagementCard.svelte
+++ b/site/src/lib/components/landing/VisitManagementCard.svelte
@@ -3,8 +3,8 @@
 	import { isIntersecting } from '$lib/utils/observer';
 	import { onDestroy, onMount } from 'svelte';
 
-	let imageRef: Element = $state();
-	let textRef: Element = $state();
+	let imageRef: Element | undefined = $state();
+	let textRef: Element | undefined = $state();
 
 	let imageObserver: IntersectionObserver | undefined;
 	let textObserver: IntersectionObserver | undefined;
@@ -13,13 +13,13 @@
 		imageObserver = isIntersecting(managementImageVisible);
 		textObserver = isIntersecting(managementTextVisible);
 
-		imageObserver?.observe(imageRef);
-		textObserver?.observe(textRef);
+		if (imageRef) imageObserver?.observe(imageRef);
+		if (textRef) textObserver?.observe(textRef);
 	});
 
 	onDestroy(() => {
-		imageObserver?.unobserve(imageRef);
-		textObserver?.unobserve(textRef);
+		if (imageRef) imageObserver?.unobserve(imageRef);
+		if (textRef) textObserver?.unobserve(textRef);
 	});
 </script>
 

--- a/site/src/lib/components/landing/VisitsCard.svelte
+++ b/site/src/lib/components/landing/VisitsCard.svelte
@@ -3,8 +3,8 @@
 	import { isIntersecting } from '$lib/utils/observer';
 	import { onDestroy, onMount } from 'svelte';
 
-	let imageRef: Element = $state();
-	let textRef: Element = $state();
+	let imageRef: Element | undefined = $state();
+	let textRef: Element | undefined = $state();
 
 	let imageObserver: IntersectionObserver | undefined;
 	let textObserver: IntersectionObserver | undefined;
@@ -13,13 +13,13 @@
 		imageObserver = isIntersecting(visitsImageVisible);
 		textObserver = isIntersecting(visitsTextVisible);
 
-		imageObserver?.observe(imageRef);
-		textObserver?.observe(textRef);
+		if (imageRef) imageObserver?.observe(imageRef);
+		if (textRef) textObserver?.observe(textRef);
 	});
 
 	onDestroy(() => {
-		imageObserver?.unobserve(imageRef);
-		textObserver?.unobserve(textRef);
+		if (imageRef) imageObserver?.unobserve(imageRef);
+		if (textRef) textObserver?.unobserve(textRef);
 	});
 </script>
 


### PR DESCRIPTION
## Context

`npm run check` reported 17 errors in `site/`. Every one is the same mistake: refs bound with `bind:this` are annotated as `Element`, but Svelte 5 leaves them `undefined` until the element mounts, so the annotation was never true.

## Solution

Widen the annotation to `Element | undefined` and guard the `observe` and `unobserve` calls, which is what the type was hiding. `svelte-check` now reports zero errors.

## Worth knowing

These errors were invisible in CI, which only builds `site/` and runs lint and typecheck against the root project. The scroll reveal driven by these observers was exercised in a browser afterwards: all 16 animated elements still fade in on intersection.